### PR TITLE
Fix buzzer event mismatch

### DIFF
--- a/frontend/src/hooks/useSocket.ts
+++ b/frontend/src/hooks/useSocket.ts
@@ -61,8 +61,12 @@ export const useSocket = (callbacks: SocketCallbacks = {}) => {
     newSocket.on("connect_error", (error) => {
       console.error("Socket connection error:", error);
     });
-    newSocket.on("buzzer-pressed", ({ teamName, playerName }) => {
+    newSocket.on("buzzer-pressed", (data) => {
+      const { teamName, playerName } = data;
       console.log(`${teamName} buzzed first! ${playerName}, answer now!`);
+      if (callbacks.onPlayerBuzzed) {
+        callbacks.onPlayerBuzzed(data);
+      }
     });
     
     newSocket.on("buzz-too-late", () => {
@@ -86,9 +90,7 @@ export const useSocket = (callbacks: SocketCallbacks = {}) => {
       newSocket.on("game-started", callbacks.onGameStarted);
     }
 
-    if (callbacks.onPlayerBuzzed) {
-      newSocket.on("player-buzzed", callbacks.onPlayerBuzzed);
-    }
+    // Buzzer events handled above via "buzzer-pressed"
 
     if (callbacks.onBuzzTooLate) {
       newSocket.on("buzz-too-late", callbacks.onBuzzTooLate);
@@ -200,7 +202,7 @@ export const useSocket = (callbacks: SocketCallbacks = {}) => {
       return;
     }
   
-    socketRef.current.emit("buzz-in", {
+    socketRef.current.emit("player-buzz", {
       gameCode: code,
       playerId,
     });

--- a/frontend/src/pages/JoinGamePage.tsx
+++ b/frontend/src/pages/JoinGamePage.tsx
@@ -210,10 +210,12 @@ const JoinGamePage: React.FC = () => {
       setError(data.message || "Answer rejected");
       setTimeout(() => setError(""), 3000);
     },
-    onPlayerBuzzed: ({ game, playerId }) => {
+    onPlayerBuzzed: (data: any) => {
       // Handle buzz-in and update state
-      setGame(game);
-      if (player?.id === playerId) setHasBuzzed(true);
+      if (data.game) {
+        setGame(data.game);
+      }
+      if (player?.id === data.playerId) setHasBuzzed(true);
     },
   });
 

--- a/server/socket/playerEvents.js
+++ b/server/socket/playerEvents.js
@@ -290,11 +290,13 @@ socket.on("submit-answer", (data) => {
     // Register the team that buzzed
     game.buzzedTeamId = player.teamId;
     game.teams.forEach((t) => (t.active = t.id === player.teamId));
-    updateGame(gameCode, game);
-  
+    const updatedGame = updateGame(gameCode, game);
+
     io.to(gameCode).emit("buzzer-pressed", {
+      game: updatedGame,
+      playerId: player.id,
       teamId: player.teamId,
-      teamName: game.teams.find((t) => t.id === player.teamId)?.name,
+      teamName: updatedGame.teams.find((t) => t.id === player.teamId)?.name,
       playerName: player.name,
     });
   });


### PR DESCRIPTION
## Summary
- emit `player-buzz` event when buzzing in
- forward `buzzer-pressed` payload to callbacks
- adapt JoinGamePage to new buzzer payload
- include updated game state in `buzzer-pressed` server event

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `npm test --silent` in `server`

------
https://chatgpt.com/codex/tasks/task_e_688135a306fc833198a2e4e8598efc67