### PR TITLE
Fix toss-up tie breaker

### DIFF
--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -15,6 +15,7 @@ export interface Game {
   id: string;
   code: string;
   buzzedTeamId?: string;
+  activeTeamId?: string;
   status: "waiting" | "active" | "round-summary" | "finished";
   currentQuestionIndex: number;
   currentRound: number;

--- a/server/services/gameService.js
+++ b/server/services/gameService.js
@@ -220,6 +220,8 @@ function createGame() {
     players: [],
     hostId: null,
     createdAt: new Date(),
+    buzzedTeamId: null,
+    activeTeamId: null,
     gameState: {
       currentTurn: null,
       questionsAnswered: {

--- a/server/socket/playerEvents.js
+++ b/server/socket/playerEvents.js
@@ -100,7 +100,6 @@ socket.on("submit-answer", (data) => {
   if (currentRound === 0) {
     if (!game.tossUpAnswers) game.tossUpAnswers = [];
     if (!game.tossUpSubmittedTeams) game.tossUpSubmittedTeams = [];
-    if (!game.buzzOrder) game.buzzOrder = [];
 
     const teamId = player.teamId;
 
@@ -167,7 +166,8 @@ socket.on("submit-answer", (data) => {
         } else if (answer2.score > answer1.score) {
           winnerTeamId = answer2.teamId;
         } else {
-          winnerTeamId = game.buzzOrder?.[0]; // Tie → use buzz order
+          // Tie - use the team that buzzed first
+          winnerTeamId = game.buzzedTeamId;
         }
 
         game.teams.forEach((t) => {


### PR DESCRIPTION
## Summary
- fix toss-up tie breaker using the first buzzing team
- track buzzer and active team in game state
- update TypeScript `Game` interface

## Testing
- `npm test --silent` (fails: `react-scripts: not found`)
- `npm test --silent` in server (prints "Error: no test specified")

------
https://chatgpt.com/codex/tasks/task_e_688138f1cafc8331bc4e48aad3942f91