### PR TITLE
Fix toss-up switching logic

### DIFF
--- a/frontend/src/components/game/RoundSummaryComponent.tsx
+++ b/frontend/src/components/game/RoundSummaryComponent.tsx
@@ -21,7 +21,7 @@ const RoundSummaryComponent: React.FC<RoundSummaryProps> = ({
   onContinueToNextRound,
   onBackToHome,
 }) => {
-  const { round, teamScores } = roundSummary;
+  const { round, teamScores, tossUpWinner } = roundSummary;
   const team1Score = teamScores.team1.roundScore;
   const team2Score = teamScores.team2.roundScore;
   const roundWinner =
@@ -72,9 +72,18 @@ const RoundSummaryComponent: React.FC<RoundSummaryProps> = ({
             <div className="mb-6">
               <span className="text-5xl mb-2 block">🏆</span>
               <h2 className="text-3xl font-bold text-slate-800 mb-2">
-                {isGameFinished ? "Final Results" : `Round ${round} Summary`}
+                {isGameFinished
+                  ? "Final Results"
+                  : round === 0
+                  ? "Toss-up Summary"
+                  : `Round ${round} Summary`}
               </h2>
-              {roundWinner && !isGameFinished && (
+              {round === 0 && tossUpWinner && !isGameFinished && (
+                <p className="text-lg text-yellow-600 font-semibold">
+                  {tossUpWinner.teamName} will start Round 1!
+                </p>
+              )}
+              {round !== 0 && roundWinner && !isGameFinished && (
                 <p className="text-lg text-yellow-600 font-semibold">
                   {roundWinner.teamName} wins this round!
                 </p>

--- a/frontend/src/pages/HostGamePage.tsx
+++ b/frontend/src/pages/HostGamePage.tsx
@@ -176,16 +176,36 @@ const HostGamePage: React.FC = () => {
       }
     });
 
-    socket.on("round-complete", (data) => {
-      console.log("🏁 Round completed:", data);
-      setGame(data.game);
-      setRoundSummary(data.roundSummary);
-      setControlMessage(
-        `Round ${data.roundSummary.round} completed! ${
-          data.isGameFinished ? "Game finished!" : "Ready for next round."
-        }`
-      );
-    });
+      socket.on("round-complete", (data) => {
+        console.log("🏁 Round completed:", data);
+
+        // Update game state if provided
+        if (data.game) {
+          setGame(data.game);
+        }
+
+        if (data.roundSummary) {
+          setRoundSummary(data.roundSummary);
+          if (data.roundSummary.round === 0) {
+            setControlMessage(
+              `${data.roundSummary.tossUpWinner?.teamName || "A team"} won the toss-up!`
+            );
+          } else {
+            setControlMessage(
+              `Round ${data.roundSummary.round} completed! ${
+                data.isGameFinished ? "Game finished!" : "Ready for next round."
+              }`
+            );
+          }
+        } else if (typeof data.round !== "undefined") {
+          // Fallback when summary is missing
+          setControlMessage(
+            `Round ${data.round} completed! ${
+              data.isGameFinished ? "Game finished!" : "Ready for next round."
+            }`
+          );
+        }
+      });
 
     socket.on("round-started", (data) => {
       console.log("🆕 New round started:", data);

--- a/frontend/src/pages/JoinGamePage.tsx
+++ b/frontend/src/pages/JoinGamePage.tsx
@@ -151,22 +151,38 @@ const JoinGamePage: React.FC = () => {
       setGame(data.game);
       setGameMessage(`It's now ${data.teamName}'s turn!`);
     },
-    onNextQuestion: (data: any) => {
-      console.log("Next question event received:", data);
-      setGame(data.game);
-      setAnswer("");
-      if (data.sameTeam) {
-        setGameMessage("Same team continues with their next question.");
-      } else {
-        setGameMessage("Moving to next question.");
-      }
-    },
-    onRoundComplete: (data: any) => {
-      console.log("Round complete event received:", data);
-      setGame(data.game);
-      setRoundSummary(data.roundSummary);
-      setGameMessage(`Round ${data.roundSummary.round} completed!`);
-    },
+      onNextQuestion: (data: any) => {
+        console.log("Next question event received:", data);
+        setGame(data.game);
+        setAnswer("");
+        if (data.sameTeam) {
+          setGameMessage("Same team continues with their next question.");
+        } else {
+          setGameMessage("Moving to next question.");
+        }
+      },
+      onRoundComplete: (data: any) => {
+        console.log("Round complete event received:", data);
+
+        // Update local game state when provided
+        if (data.game) {
+          setGame(data.game);
+        }
+
+        if (data.roundSummary) {
+          setRoundSummary(data.roundSummary);
+          if (data.roundSummary.round === 0) {
+            setGameMessage(
+              `${data.roundSummary.tossUpWinner?.teamName || "A team"} won the toss-up!`
+            );
+          } else {
+            setGameMessage(`Round ${data.roundSummary.round} completed!`);
+          }
+        } else if (typeof data.round !== "undefined") {
+          // Fallback to a simple message when summary is missing
+          setGameMessage(`Round ${data.round} completed!`);
+        }
+      },
     onRoundStarted: (data: any) => {
       console.log("Round started event received:", data);
       setGame(data.game);
@@ -475,6 +491,30 @@ const JoinGamePage: React.FC = () => {
                       </button>
                     </div>
                   )
+                ) : isMyTurn ? (
+                  <div className="max-w-md mx-auto">
+                    <input
+                      type="text"
+                      value={answer}
+                      onChange={(e) => setAnswer(e.target.value)}
+                      onKeyPress={handleKeyPress}
+                      placeholder="Type your answer here..."
+                      disabled={!canAnswer}
+                      autoFocus={true}
+                      className="w-full px-4 py-3 text-lg font-semibold rounded-lg bg-white text-gray-900 border-2 border-green-400 focus:outline-none focus:border-green-300 focus:ring-4 focus:ring-green-300/30 transition-all shadow-md placeholder-gray-500"
+                    />
+                    <button
+                      onClick={handleSubmitAnswer}
+                      disabled={!answer.trim() || !canAnswer}
+                      className={`w-full py-3 px-6 mt-2 rounded-lg font-bold text-lg transition-all transform shadow-lg ${
+                        canAnswer && answer.trim()
+                          ? "bg-gradient-to-r from-green-600 to-green-700 hover:from-green-700 hover:to-green-800 text-white hover:scale-105 active:scale-95"
+                          : "bg-gray-500 text-gray-300 cursor-not-allowed opacity-60"
+                      }`}
+                    >
+                      {answer.trim() ? "Submit Answer" : "Type an answer..."}
+                    </button>
+                  </div>
                 ) : (
                   <div className="p-6 bg-gray-700/30 rounded-lg backdrop-blur">
                     <div className="flex items-center justify-center gap-3 mb-3">

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -65,6 +65,14 @@ export interface Answer {
   revealed: boolean;
 }
 
+export interface TossUpAnswer {
+  teamId: string;
+  teamName: string;
+  playerName: string;
+  answer: string;
+  score: number;
+}
+
 export interface Team {
   id: string;
   name: string;
@@ -96,6 +104,8 @@ export interface RoundSummary {
     team1: Question[];
     team2: Question[];
   };
+  tossUpWinner?: { teamId: string; teamName: string };
+  tossUpAnswers?: TossUpAnswer[];
 }
 
 // Base socket event data types

--- a/server/services/gameService.js
+++ b/server/services/gameService.js
@@ -144,27 +144,68 @@ function calculateRoundSummary(game) {
   };
 }
 
+// Create a summary object for the toss-up round
+function calculateTossUpSummary(game) {
+  const team1 = getTeamByAssignment(game, "team1");
+  const team2 = getTeamByAssignment(game, "team2");
+
+  let winner = null;
+  if (game.tossUpAnswers && game.tossUpAnswers.length > 0) {
+    winner = game.tossUpAnswers.reduce((a, b) => (a.score > b.score ? a : b));
+  }
+
+  return {
+    round: 0,
+    tossUpWinner: winner
+      ? { teamId: winner.teamId, teamName: winner.teamName }
+      : null,
+    tossUpAnswers: game.tossUpAnswers || [],
+    teamScores: {
+      team1: {
+        roundScore: 0,
+        totalScore: team1 ? team1.score : 0,
+        teamName: team1 ? team1.name : "Team 1",
+      },
+      team2: {
+        roundScore: 0,
+        totalScore: team2 ? team2.score : 0,
+        teamName: team2 ? team2.name : "Team 2",
+      },
+    },
+    questionsAnswered: {
+      team1: [],
+      team2: [],
+    },
+  };
+}
+
 // Start new round
 function startNewRound(game) {
   game.currentRound += 1;
   game.gameState.questionsAnswered.team1 = 0;
   game.gameState.questionsAnswered.team2 = 0;
-  game.gameState.currentTurn = "team1"; // Team 1 always starts each round
+
+  // Determine which team should start this round.
+  // By default team1 would start, but after the toss-up the winning team
+  // should begin every subsequent round.
+  let startingTeam = "team1";
+  if (game.tossUpWinner && game.tossUpWinner.teamId) {
+    startingTeam = game.tossUpWinner.teamId.includes("team1") ? "team1" : "team2";
+  }
+  game.gameState.currentTurn = startingTeam;
 
   // Reset round scores
   game.teams.forEach((team) => {
     team.currentRoundScore = 0;
   });
 
-  // Set to first question of new round for team1
-  const team1FirstQuestion = game.questions.find(
-    (q) => q.teamAssignment === "team1" && q.round === game.currentRound
+  // Set to first question of new round for starting team
+  const firstQuestion = game.questions.find(
+    (q) => q.teamAssignment === startingTeam && q.round === game.currentRound
   );
 
-  if (team1FirstQuestion) {
-    game.currentQuestionIndex = game.questions.findIndex(
-      (q) => q.id === team1FirstQuestion.id
-    );
+  if (firstQuestion) {
+    game.currentQuestionIndex = game.questions.findIndex((q) => q.id === firstQuestion.id);
   }
 
   // Update team active status
@@ -222,6 +263,9 @@ function createGame() {
     createdAt: new Date(),
     buzzedTeamId: null,
     activeTeamId: null,
+    // Stores the winning team of the toss-up round so that
+    // subsequent rounds start with the correct team
+    tossUpWinner: null,
     gameState: {
       currentTurn: null,
       questionsAnswered: {
@@ -354,36 +398,16 @@ function submitAnswer(gameCode, playerId, answerText) {
       revealAllCards: !matchingAnswer,
     };
 
-    // If both teams answered, decide toss-up winner
+    // If both teams answered, just store the winning team for the next round
     if (game.tossUpSubmittedTeams.length === 2) {
       const best = game.tossUpAnswers.reduce((a, b) =>
         a.score > b.score ? a : b
       );
 
-      game.teams.forEach((t) => {
-        t.active = t.id === best.teamId;
-      });
-
-      game.gameState.currentTurn = best.teamId.includes("team1") ? "team1" : "team2";
-      game.currentRound = 1;
-      game.tossUpComplete = true;
-      game.status = "active";
       game.tossUpWinner = best;
+      game.tossUpComplete = true;
 
-      // Move to first question of winning team for round 1
-      const firstQ = game.questions.find(
-        (q) =>
-          q.round === 1 &&
-          ((game.gameState.currentTurn === "team1" && q.teamAssignment === "team1") ||
-           (game.gameState.currentTurn === "team2" && q.teamAssignment === "team2")) &&
-          q.questionNumber === 1
-      );
-
-      if (firstQ) {
-        game.currentQuestionIndex = game.questions.findIndex((q) => q.id === firstQ.id);
-      }
-
-      updateTeamActiveStatus(game);
+      // No round advancement here; host will continue to next round
     }
 
     return response;
@@ -692,6 +716,7 @@ module.exports = {
   getCurrentQuestion,
   getQuestionsForTeamRound,
   calculateRoundSummary,
+  calculateTossUpSummary,
   isRoundComplete,
   checkAnswerMatch,
   getTeamByAssignment,

--- a/server/socket/playerEvents.js
+++ b/server/socket/playerEvents.js
@@ -6,6 +6,7 @@ const {
   submitAnswer,
   advanceGameState,
   getCurrentQuestion,
+  calculateTossUpSummary,
 } = require("../services/gameService");
 
 function setupPlayerEvents(socket, io) {
@@ -120,15 +121,9 @@ socket.on("submit-answer", (data) => {
       return;
     }
 
-    game.tossUpSubmittedTeams.push(teamId);
-    game.tossUpAnswers.push({
-      teamId,
-      teamName: result.teamName,
-      score: result.pointsAwarded,
-      playerName: result.playerName,
-      answer: result.matchingAnswer,
-      submittedText: answer,
-    });
+    // The service already records the team's answer and marks them as having
+    // submitted. Avoid duplicating that state here so the toss-up round waits
+    // for both teams correctly.
 
     // Emit answer result
     if (result.isCorrect) {
@@ -171,13 +166,24 @@ socket.on("submit-answer", (data) => {
         }
 
         game.teams.forEach((t) => {
-          t.active = t.id === winnerTeamId;
+          t.active = false;
         });
 
+        const summary = calculateTossUpSummary(game);
+
+        game.status = "round-summary";
+        game.gameState.currentTurn = null;
+        game.tossUpWinner = {
+          teamId: winnerTeamId,
+          teamName: game.teams.find((t) => t.id === winnerTeamId)?.name,
+        };
+
+        updateGame(gameCode, game);
+
         io.to(gameCode).emit("round-complete", {
-          round: 0,
-          tossUpAnswers: game.tossUpAnswers,
-          winnerTeamId,
+          game,
+          roundSummary: summary,
+          isGameFinished: false,
         });
 
         console.log(`🏆 Toss-up round winner: ${winnerTeamId}`);
@@ -187,25 +193,25 @@ socket.on("submit-answer", (data) => {
       const [teamA, teamB] = game.teams;
       const otherTeamId = teamA.id === teamId ? teamB.id : teamA.id;
 
-      game.buzzedTeamId = otherTeamId;
+      // Keep the original buzzed team for tie-break purposes but switch the
+      // active team to allow the second team to answer.
       game.activeTeamId = otherTeamId;
       game.teams.forEach((t) => (t.active = t.id === otherTeamId));
       game.gameState.inputEnabled = true;
+      game.gameState.currentTurn = otherTeamId.includes("team1") ? "team1" : "team2";
 
-      io.to(gameCode).emit("onPlayerBuzzed", {
-        game,
-        playerId: null,
-        teamId: otherTeamId,
-      });
+      const updatedGame = updateGame(gameCode, game);
 
-      io.to(gameCode).emit("team-switched", {
-        currentTeamId: game.activeTeamId,
+      io.to(gameCode).emit("turn-changed", {
+        game: updatedGame,
+        newActiveTeam: updatedGame.gameState.currentTurn,
+        teamName: updatedGame.teams.find((t) => t.active)?.name || "Unknown",
+        currentQuestion: getCurrentQuestion(updatedGame),
       });
 
       console.log(`🔁 Switching to Team ${otherTeamId}`);
     }
 
-    updateGame(gameCode, game);
     return;
   }
 


### PR DESCRIPTION
## Summary
- avoid recording toss-up answers twice
- keep the original buzzed team while switching to the second team
- correctly emit a turn change so the second team can answer

## Testing
- `npm test --prefix frontend -- --watchAll=false` *(fails: react-scripts not found)*
- `npm test --prefix server` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68813bfdebfc8331b308f2443e48fde4