### PR TITLE
Fix final round summary

### DIFF
--- a/server/services/gameService.js
+++ b/server/services/gameService.js
@@ -568,6 +568,20 @@ export function advanceGameState(gameCode) {
         updateTeamActiveStatus(game);
       } else {
         // Game finished
+        const roundKey = `round${game.currentRound}`;
+        const team1 = game.teams.find((t) => t.id.includes("team1"));
+        const team2 = game.teams.find((t) => t.id.includes("team2"));
+
+        if (team1 && team2) {
+          game.gameState.roundScores[roundKey] = {
+            team1: team1.currentRoundScore,
+            team2: team2.currentRoundScore,
+          };
+
+          team1.roundScores[game.currentRound - 1] = team1.currentRoundScore;
+          team2.roundScores[game.currentRound - 1] = team2.currentRoundScore;
+        }
+
         game.status = "finished";
         game.gameState.currentTurn = null;
         updateTeamActiveStatus(game);

--- a/server/socket/playerEvents.js
+++ b/server/socket/playerEvents.js
@@ -357,12 +357,14 @@ export function handleGameStateAdvancement(gameCode, advancedGame, io, result) {
 
     console.log(`🏁 Round ${advancedGame.currentRound} completed`);
   } else if (advancedGame.status === "finished") {
-    // Game finished
+    // Game finished - include round summary for final round
     const winner = getGameWinner(advancedGame);
+    const roundSummary = calculateRoundSummary(advancedGame);
 
     io.to(gameCode).emit("game-over", {
       game: advancedGame,
       winner: winner,
+      roundSummary,
     });
 
     console.log(`🏆 Game finished: ${gameCode}`);


### PR DESCRIPTION
## Summary
- track final round scores when the last question is answered
- include the last round summary when emitting the `game-over` event

## Testing
- `npm test` (no tests present)


------
https://chatgpt.com/codex/tasks/task_e_688793e1b2508331ba737fb9a2ad600e