### PR TITLE
Fix host force-next and tiebreak round logic

### DIFF
--- a/server/services/gameService.js
+++ b/server/services/gameService.js
@@ -212,14 +212,17 @@ function startNewRound(game) {
     team.currentRoundScore = 0;
   });
 
-  // Set to first question of new round for team1
-  const team1FirstQuestion = game.questions.find(
-    (q) => q.teamAssignment === "team1" && q.round === game.currentRound
+  // Set to first question of new round for the starting team
+  const firstQuestion = game.questions.find(
+    (q) =>
+      q.teamAssignment === startingTeam &&
+      q.round === game.currentRound &&
+      q.questionNumber === 1
   );
 
-  if (team1FirstQuestion) {
+  if (firstQuestion) {
     game.currentQuestionIndex = game.questions.findIndex(
-      (q) => q._id === team1FirstQuestion._id
+      (q) => q._id === firstQuestion._id
     );
   }
 
@@ -568,6 +571,20 @@ export function advanceGameState(gameCode) {
         updateTeamActiveStatus(game);
       } else {
         // Game finished
+        const roundKey = `round${game.currentRound}`;
+        const team1 = game.teams.find((t) => t.id.includes("team1"));
+        const team2 = game.teams.find((t) => t.id.includes("team2"));
+
+        if (team1 && team2) {
+          game.gameState.roundScores[roundKey] = {
+            team1: team1.currentRoundScore,
+            team2: team2.currentRoundScore,
+          };
+
+          team1.roundScores[game.currentRound - 1] = team1.currentRoundScore;
+          team2.roundScores[game.currentRound - 1] = team2.currentRoundScore;
+        }
+
         game.status = "finished";
         game.gameState.currentTurn = null;
         updateTeamActiveStatus(game);

--- a/server/socket/hostEvents.js
+++ b/server/socket/hostEvents.js
@@ -6,7 +6,10 @@ import {
   getCurrentQuestion,
   calculateRoundSummary,
   initializeQuestionData,
+  updateQuestionData,
+  advanceGameState,
 } from "../services/gameService.js";
+import { handleGameStateAdvancement } from "./playerEvents.js";
 
 export function setupHostEvents(socket, io) {
   // Host joins game
@@ -176,37 +179,49 @@ export function setupHostEvents(socket, io) {
     if (game && game.hostId === socket.id && game.status === "active") {
       console.log(`⚠️ Host forcing next question in game: ${gameCode}`);
 
-      // Manually advance question index
-      game.currentQuestionIndex += 1;
-
-      // Update turn logic
       const currentQuestion = getCurrentQuestion(game);
       if (currentQuestion) {
-        game.gameState.currentTurn = currentQuestion.teamAssignment;
+        // Reveal all answers
+        currentQuestion.answers.forEach((a) => (a.revealed = true));
 
-        // Update team active status
-        game.teams.forEach((team) => {
-          if (currentQuestion.teamAssignment === "team1") {
-            team.active = team.id.includes("team1") || team.name.includes("1");
-          } else {
-            team.active = team.id.includes("team2") || team.name.includes("2");
-          }
+        // Record skipped question as incorrect
+        const teamKey = game.gameState.currentTurn;
+        const questionNumber =
+          game.gameState.questionsAnswered[teamKey] + 1;
+        updateQuestionData(
+          game,
+          teamKey,
+          game.currentRound,
+          questionNumber,
+          false,
+          0
+        );
+
+        updateGame(gameCode, game);
+
+        io.to(gameCode).emit("answers-revealed", {
+          game,
+          currentQuestion,
+          byHost: true,
+        });
+      }
+
+      const advancedGame = advanceGameState(gameCode);
+      if (advancedGame) {
+        handleGameStateAdvancement(gameCode, advancedGame, io, {
+          teamName: "Host", // placeholder
+          game,
         });
 
-        // Reset attempts for forced question
-        game.gameState.currentQuestionAttempts = 0;
-
-        const updatedGame = updateGame(gameCode, game);
-
         io.to(gameCode).emit("question-forced", {
-          game: updatedGame,
-          currentQuestion: currentQuestion,
-          activeTeam: game.gameState.currentTurn,
+          game: advancedGame,
+          currentQuestion: getCurrentQuestion(advancedGame),
+          activeTeam: advancedGame.gameState.currentTurn,
           byHost: true,
         });
 
         console.log(
-          `⚠️ Host forced advance to question ${game.currentQuestionIndex + 1}`
+          `⚠️ Host forced advance to question ${advancedGame.currentQuestionIndex + 1}`
         );
       }
     }

--- a/server/socket/playerEvents.js
+++ b/server/socket/playerEvents.js
@@ -357,12 +357,14 @@ export function handleGameStateAdvancement(gameCode, advancedGame, io, result) {
 
     console.log(`🏁 Round ${advancedGame.currentRound} completed`);
   } else if (advancedGame.status === "finished") {
-    // Game finished
+    // Game finished - include round summary for final round
     const winner = getGameWinner(advancedGame);
+    const roundSummary = calculateRoundSummary(advancedGame);
 
     io.to(gameCode).emit("game-over", {
       game: advancedGame,
       winner: winner,
+      roundSummary,
     });
 
     console.log(`🏆 Game finished: ${gameCode}`);


### PR DESCRIPTION
## Summary
- ensure final round scores are saved before game ends
- include final round summary in the `game-over` event
- start new rounds with the correct team's question when a toss-up is won
- handle host "Force Next" by revealing the current question, recording it as incorrect and advancing normally

## Testing
- `npm test` in `server` (fails: Error: no test specified)
- `npm test` in `frontend` (no tests found)


------
https://chatgpt.com/codex/tasks/task_e_688793e1b2508331ba737fb9a2ad600e