### PR TITLE
Fix host controls and toss-up scoring

### DIFF
--- a/frontend/src/components/game/GameBoard.tsx
+++ b/frontend/src/components/game/GameBoard.tsx
@@ -5,19 +5,23 @@ import { getCurrentQuestion } from "../../utils/gameHelper";
 interface GameBoardProps {
   game: Game;
   onRevealAnswer?: (answerIndex: number) => void;
+  onSelectAnswer?: (answerIndex: number) => void;
   onNextQuestion?: () => void;
   isHost?: boolean;
   variant?: "host" | "player";
   controlMessage?: string;
+  overrideMode?: boolean;
 }
 
 const GameBoard: React.FC<GameBoardProps> = ({
   game,
   onRevealAnswer,
+  onSelectAnswer,
   onNextQuestion,
   isHost = false,
   variant = "host",
   controlMessage,
+  overrideMode = false,
 }) => {
   const currentQuestion = getCurrentQuestion(game);
 
@@ -156,10 +160,16 @@ const GameBoard: React.FC<GameBoardProps> = ({
               answer.revealed
                 ? "bg-gradient-to-r from-green-600/30 to-emerald-600/30 border-green-400 animate-pulse"
                 : "hover:border-blue-400"
-            } ${isHost && !answer.revealed ? "cursor-pointer" : ""}`}
-            onClick={() =>
-              isHost && !answer.revealed && onRevealAnswer?.(index)
-            }
+            } ${
+              isHost && (!answer.revealed || overrideMode) ? "cursor-pointer" : ""
+            }`}
+            onClick={() => {
+              if (overrideMode) {
+                onSelectAnswer?.(index);
+              } else if (isHost && !answer.revealed) {
+                onRevealAnswer?.(index);
+              }
+            }}
           >
             <span className="answer-text">
               {/* HOST ALWAYS SEES THE ANSWER TEXT */}
@@ -199,10 +209,17 @@ const GameBoard: React.FC<GameBoardProps> = ({
       </div>
 
       {/* Host Control Message */}
-      {isHost && controlMessage && (
+      {isHost && (controlMessage || overrideMode) && (
         <div className="glass-card host-controls">
           <div className="text-center">
-            <div className="text-xs text-blue-400">{controlMessage}</div>
+            {overrideMode && (
+              <div className="text-xs text-yellow-300 mb-1">
+                Select an answer to override
+              </div>
+            )}
+            {controlMessage && (
+              <div className="text-xs text-blue-400">{controlMessage}</div>
+            )}
           </div>
         </div>
       )}

--- a/frontend/src/components/game/GameBoard.tsx
+++ b/frontend/src/components/game/GameBoard.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Game } from "../../types";
 import Button from "../common/Button";
-import { getCurrentQuestion } from "../../utils/gameHelper";
+import { getCurrentQuestion, formatRoundLabel } from "../../utils/gameHelper";
 
 interface GameBoardProps {
   game: Game;
@@ -72,7 +72,7 @@ const GameBoard: React.FC<GameBoardProps> = ({
           <div className="flex justify-between items-center">
             <div>
               <h2 className="font-bold">
-                Round {game.currentRound} • {currentQuestion.questionCategory}
+                {formatRoundLabel(game.currentRound)} • {currentQuestion.questionCategory}
               </h2>
               <div className="text-xs text-slate-400">
                 Question {game.currentQuestionIndex + 1} of{" "}
@@ -137,7 +137,7 @@ const GameBoard: React.FC<GameBoardProps> = ({
         <div className="flex justify-between items-center">
           <div>
             <h2 className="font-bold">
-              Round {game.currentRound} • {currentQuestion.questionCategory}
+              {formatRoundLabel(game.currentRound)} • {currentQuestion.questionCategory}
             </h2>
             <div className="text-xs text-slate-400">
               Question {game.currentQuestionIndex + 1} of {game.questions.length}

--- a/frontend/src/components/game/GameBoard.tsx
+++ b/frontend/src/components/game/GameBoard.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Game } from "../../types";
+import Button from "../common/Button";
 import { getCurrentQuestion } from "../../utils/gameHelper";
 
 interface GameBoardProps {
@@ -209,7 +210,7 @@ const GameBoard: React.FC<GameBoardProps> = ({
       </div>
 
       {/* Host Control Message */}
-      {isHost && (controlMessage || overrideMode) && (
+      {isHost && (controlMessage || overrideMode || game.gameState.canAdvance) && (
         <div className="glass-card host-controls">
           <div className="text-center">
             {overrideMode && (
@@ -219,6 +220,16 @@ const GameBoard: React.FC<GameBoardProps> = ({
             )}
             {controlMessage && (
               <div className="text-xs text-blue-400">{controlMessage}</div>
+            )}
+            {game.gameState.canAdvance && !overrideMode && (
+              <Button
+                onClick={onNextQuestion}
+                variant="primary"
+                size="sm"
+                className="mt-2 text-xs py-1 px-3"
+              >
+                Next Question
+              </Button>
             )}
           </div>
         </div>

--- a/frontend/src/components/game/GameBoard.tsx
+++ b/frontend/src/components/game/GameBoard.tsx
@@ -112,7 +112,11 @@ const GameBoard: React.FC<GameBoardProps> = ({
                     : "bg-slate-700 text-slate-400"
                 }`}
               >
-                {answer.revealed ? answer.score * game.currentRound : "?"}
+                {answer.revealed
+                  ? game.currentRound === 0
+                    ? answer.score
+                    : answer.score * game.currentRound
+                  : "?"}
               </span>
             </div>
           ))}
@@ -184,7 +188,11 @@ const GameBoard: React.FC<GameBoardProps> = ({
                   : "bg-slate-700 text-slate-400"
               }`}
             >
-              {answer.revealed || isHost ? answer.score * game.currentRound : "?"}
+              {answer.revealed || isHost
+                ? game.currentRound === 0
+                  ? answer.score
+                  : answer.score * game.currentRound
+                : "?"}
             </span>
           </div>
         ))}

--- a/frontend/src/components/game/GameResults.tsx
+++ b/frontend/src/components/game/GameResults.tsx
@@ -4,6 +4,7 @@ import { Team } from "../../types";
 import { ROUTES } from "../../utils/constants";
 import AnimatedCard from "../common/AnimatedCard";
 import Button from "../common/Button";
+import { formatRoundLabel } from "../../utils/gameHelper";
 
 interface GameResultsProps {
   teams: Team[];
@@ -115,7 +116,7 @@ const GameResults: React.FC<GameResultsProps> = ({
                           
                           return (
                             <div key={round} className="flex justify-between items-center">
-                              <span className="text-sm text-slate-400">Round {round}:</span>
+                              <span className="text-sm text-slate-400">{formatRoundLabel(round)}:</span>
                               <span className={`font-bold ${wonRound ? 'text-yellow-400' : 'text-slate-300'}`}>
                                 {roundScore} {wonRound && '👑'}
                               </span>

--- a/frontend/src/components/game/QuestionCard.tsx
+++ b/frontend/src/components/game/QuestionCard.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Question } from "../../types";
 import AnimatedCard from "../common/AnimatedCard";
+import { formatRoundLabel } from "../../utils/gameHelper";
 
 interface QuestionCardProps {
   question: Question;
@@ -24,7 +25,7 @@ const QuestionCard: React.FC<QuestionCardProps> = ({
         <div className="glass-card p-2 mb-2 bg-gradient-to-r from-purple-600/20 to-blue-600/20 border-purple-500/30">
           <div className="flex justify-between items-center">
             <h2 className="text-base font-bold">
-              Round {currentRound} • {question.questionCategory}
+              {formatRoundLabel(currentRound)} • {question.questionCategory}
             </h2>
             <div className="text-xs text-slate-400">
               Question {questionIndex + 1} of {totalQuestions}
@@ -48,7 +49,7 @@ const QuestionCard: React.FC<QuestionCardProps> = ({
       <AnimatedCard>
         <div className="glass-card p-4 mb-4 text-center bg-gradient-to-r from-purple-600/20 to-blue-600/20">
           <h3 className="text-lg font-bold">
-            Round {currentRound} • {question.questionCategory}
+            {formatRoundLabel(currentRound)} • {question.questionCategory}
           </h3>
           <p className="text-sm text-slate-400">
             Question {questionIndex + 1} of {totalQuestions}

--- a/frontend/src/components/game/RoundSummaryComponent.tsx
+++ b/frontend/src/components/game/RoundSummaryComponent.tsx
@@ -2,6 +2,7 @@ import React, { useEffect } from "react";
 import { RoundSummary, Team } from "../../types";
 import AnimatedCard from "../common/AnimatedCard";
 import Button from "../common/Button";
+import { formatRoundLabel } from "../../utils/gameHelper";
 import confetti from "canvas-confetti";
 
 interface RoundSummaryProps {
@@ -286,7 +287,7 @@ const RoundSummaryComponent: React.FC<RoundSummaryProps> = ({
                   ))}
                 </div>
                 <div className="text-xs text-slate-500 mt-2">
-                  Round {round} of 3 Complete
+                  {formatRoundLabel(round)} of 3 Complete
                 </div>
               </div>
             )}

--- a/frontend/src/components/game/TeamPanel.tsx
+++ b/frontend/src/components/game/TeamPanel.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Team } from "../../types";
-import { getTeamColorClasses } from "../../utils/gameHelper";
+import { getTeamColorClasses, formatRoundLabel } from "../../utils/gameHelper";
 
 interface QuestionStatus {
   firstAttemptCorrect: boolean | null; // true = correct, false = incorrect, null = not attempted
@@ -212,7 +212,7 @@ const TeamPanel: React.FC<TeamPanelProps> = ({
         {/* Current Round Question Progress */}
         <div className="glass-card p-2 mb-3 bg-gradient-to-r from-red-600/20 to-red-700/20 border-red-500/30">
           <h4 className="text-sm font-bold text-red-300 mb-2 text-center">
-            Round {currentRound}
+            {formatRoundLabel(currentRound)}
           </h4>
           
           {/* Question Progress Indicators */}

--- a/frontend/src/components/game/TurnIndicator.tsx
+++ b/frontend/src/components/game/TurnIndicator.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Team, Question } from "../../types";
+import { formatRoundLabel } from "../../utils/gameHelper";
 
 interface TurnIndicatorProps {
   currentTeam: "team1" | "team2" | null;
@@ -36,7 +37,7 @@ const TurnIndicator: React.FC<TurnIndicatorProps> = ({
             🎯 {activeTeam?.name}'s Turn
           </h3>
           <p className="text-sm text-slate-300">
-            Question {questionNumber} of 3 • Round {round}
+            Question {questionNumber} of 3 • {formatRoundLabel(round)}
           </p>
           <p className="text-xs text-slate-400 mt-1">
             {waitingTeam?.name} is waiting
@@ -60,7 +61,9 @@ const TurnIndicator: React.FC<TurnIndicatorProps> = ({
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4 text-center">
           <div className="bg-slate-700/30 rounded-lg p-3">
             <div className="text-lg font-semibold text-slate-300">Round</div>
-            <div className="text-2xl font-bold text-orange-400">{round}</div>
+            <div className="text-2xl font-bold text-orange-400">
+              {formatRoundLabel(round)}
+            </div>
           </div>
 
           <div className="bg-slate-700/30 rounded-lg p-3">

--- a/frontend/src/hooks/useSocket.ts
+++ b/frontend/src/hooks/useSocket.ts
@@ -25,6 +25,7 @@ interface SocketCallbacks {
   onRoundComplete?: (data: any) => void;
   onRoundStarted?: (data: any) => void;
   onQuestionForced?: (data: any) => void;
+  onQuestionComplete?: (data: any) => void;
   onGameReset?: (data: any) => void;
   onAnswersRevealed?: (data: any) => void;
   // NEW: Card revelation events
@@ -159,6 +160,10 @@ export const useSocket = (callbacks: SocketCallbacks = {}) => {
       newSocket.on("question-forced", callbacks.onQuestionForced);
     }
 
+    if (callbacks.onQuestionComplete) {
+      newSocket.on("question-complete", callbacks.onQuestionComplete);
+    }
+
     if (callbacks.onGameReset) {
       newSocket.on("game-reset", callbacks.onGameReset);
     }
@@ -226,6 +231,12 @@ export const useSocket = (callbacks: SocketCallbacks = {}) => {
   const forceNextQuestion = (gameCode: string) => {
     if (socketRef.current) {
       socketRef.current.emit("force-next-question", { gameCode });
+    }
+  };
+
+  const advanceQuestion = (gameCode: string) => {
+    if (socketRef.current) {
+      socketRef.current.emit("advance-question", { gameCode });
     }
   };
 
@@ -310,6 +321,7 @@ export const useSocket = (callbacks: SocketCallbacks = {}) => {
     hostJoinGame,
     startGame,
     continueToNextRound,
+    advanceQuestion,
     forceNextQuestion,
     forceRoundSummary,
     overrideAnswer,

--- a/frontend/src/hooks/useSocket.ts
+++ b/frontend/src/hooks/useSocket.ts
@@ -26,6 +26,7 @@ interface SocketCallbacks {
   onRoundStarted?: (data: any) => void;
   onQuestionForced?: (data: any) => void;
   onGameReset?: (data: any) => void;
+  onAnswersRevealed?: (data: any) => void;
   // NEW: Card revelation events
   onRemainingCardsRevealed?: (data: any) => void;
 }
@@ -159,6 +160,10 @@ export const useSocket = (callbacks: SocketCallbacks = {}) => {
 
     if (callbacks.onGameReset) {
       newSocket.on("game-reset", callbacks.onGameReset);
+    }
+
+    if (callbacks.onAnswersRevealed) {
+      newSocket.on("answers-revealed", callbacks.onAnswersRevealed);
     }
 
     // NEW: Card revelation events

--- a/frontend/src/hooks/useSocket.ts
+++ b/frontend/src/hooks/useSocket.ts
@@ -29,6 +29,7 @@ interface SocketCallbacks {
   onAnswersRevealed?: (data: any) => void;
   // NEW: Card revelation events
   onRemainingCardsRevealed?: (data: any) => void;
+  onAnswerOverridden?: (data: any) => void;
 }
 
 export const useSocket = (callbacks: SocketCallbacks = {}) => {
@@ -171,6 +172,10 @@ export const useSocket = (callbacks: SocketCallbacks = {}) => {
       newSocket.on("remaining-cards-revealed", callbacks.onRemainingCardsRevealed);
     }
 
+    if (callbacks.onAnswerOverridden) {
+      newSocket.on("answer-overridden", callbacks.onAnswerOverridden);
+    }
+
     socketRef.current = newSocket;
     setSocket(newSocket);
     return newSocket;
@@ -236,6 +241,26 @@ export const useSocket = (callbacks: SocketCallbacks = {}) => {
     }
   };
 
+  const overrideAnswer = (
+    gameCode: string,
+    teamId: string,
+    round: number,
+    questionNumber: number,
+    isCorrect: boolean,
+    points: number
+  ) => {
+    if (socketRef.current) {
+      socketRef.current.emit("override-answer", {
+        gameCode,
+        teamId,
+        round,
+        questionNumber,
+        isCorrect,
+        pointsAwarded: points,
+      });
+    }
+  };
+
   // Player actions
   const playerJoinGame = (gameCode: string, playerId: string) => {
     if (socketRef.current) {
@@ -285,6 +310,7 @@ export const useSocket = (callbacks: SocketCallbacks = {}) => {
     continueToNextRound,
     forceNextQuestion,
     forceRoundSummary,
+    overrideAnswer,
     resetGame,
     buzzIn,
     requestPlayersList,

--- a/frontend/src/hooks/useSocket.ts
+++ b/frontend/src/hooks/useSocket.ts
@@ -247,7 +247,8 @@ export const useSocket = (callbacks: SocketCallbacks = {}) => {
     round: number,
     questionNumber: number,
     isCorrect: boolean,
-    points: number
+    points: number,
+    answerIndex: number
   ) => {
     if (socketRef.current) {
       socketRef.current.emit("override-answer", {
@@ -257,6 +258,7 @@ export const useSocket = (callbacks: SocketCallbacks = {}) => {
         questionNumber,
         isCorrect,
         pointsAwarded: points,
+        answerIndex,
       });
     }
   };

--- a/frontend/src/pages/HostGamePage.tsx
+++ b/frontend/src/pages/HostGamePage.tsx
@@ -179,6 +179,12 @@ const HostGamePage: React.FC = () => {
       }
     });
 
+    socket.on("question-complete", (data) => {
+      console.log("🟢 Question complete:", data);
+      setGame(data.game);
+      setControlMessage("Question finished. Click Next Question when ready.");
+    });
+
       socket.on("round-complete", (data) => {
         console.log("🏁 Round completed:", data);
 
@@ -340,6 +346,12 @@ const HostGamePage: React.FC = () => {
   const handleForceNextQuestion = () => {
     if (gameCode && socketRef.current) {
       socketRef.current.emit("force-next-question", { gameCode });
+    }
+  };
+
+  const handleNextQuestion = () => {
+    if (gameCode && socketRef.current) {
+      socketRef.current.emit("advance-question", { gameCode });
     }
   };
 
@@ -556,6 +568,7 @@ const HostGamePage: React.FC = () => {
             controlMessage={controlMessage}
             overrideMode={overrideMode}
             onSelectAnswer={handleSelectOverride}
+            onNextQuestion={handleNextQuestion}
           />
 
           {/* Host Controls - CLEAN VERSION */}
@@ -564,6 +577,15 @@ const HostGamePage: React.FC = () => {
               <div className="text-sm text-slate-400 mb-2">Host Controls</div>
             </div>
             <div className="flex gap-2 justify-center flex-wrap">
+              <Button
+                onClick={handleNextQuestion}
+                variant="primary"
+                size="sm"
+                className="text-xs py-1 px-3"
+                disabled={!game?.gameState.canAdvance}
+              >
+                ➡️ Next Question
+              </Button>
               <Button
                 onClick={handleForceNextQuestion}
                 variant="secondary"

--- a/frontend/src/pages/HostGamePage.tsx
+++ b/frontend/src/pages/HostGamePage.tsx
@@ -358,7 +358,9 @@ const HostGamePage: React.FC = () => {
       )?.id;
       if (!teamId) return;
       const questionNumber = game.gameState.questionsAnswered[teamKey] + 1;
-      const answer = getCurrentQuestion(game).answers[answerIndex];
+      const currentQuestion = getCurrentQuestion(game);
+      if (!currentQuestion) return;
+      const answer = currentQuestion.answers[answerIndex];
       const points =
         game.currentRound === 0 ? answer.score : answer.score * game.currentRound;
 
@@ -401,7 +403,7 @@ const HostGamePage: React.FC = () => {
     return () => {
       if (interval) clearInterval(interval);
     };
-  }, [game?.status, gameCode]);
+  }, [game, gameCode]);
 
   // Cleanup socket on unmount
   useEffect(() => {

--- a/frontend/src/pages/HostGamePage.tsx
+++ b/frontend/src/pages/HostGamePage.tsx
@@ -250,6 +250,13 @@ const HostGamePage: React.FC = () => {
       setControlMessage("All answers have been revealed!");
     });
 
+    socket.on("game-reset", (data) => {
+      console.log("🔄 Game reset:", data);
+      setGame(data.game);
+      setRoundSummary(null);
+      setControlMessage(data.message || "Game has been reset.");
+    });
+
     socket.on("connect_error", (error) => {
       console.error("❌ Socket connection error:", error);
       setControlMessage("Connection error. Please try again.");
@@ -326,12 +333,6 @@ const HostGamePage: React.FC = () => {
     }
   };
 
-  const handleRevealAllAnswers = () => {
-    if (socketRef.current && gameCode && game && game.status === "active") {
-      socketRef.current.emit("reveal-all-answers", { gameCode });
-      setControlMessage("Revealing all answers for this question...");
-    }
-  };
 
   const handleResetGame = () => {
     if (gameCode && socketRef.current) {
@@ -515,14 +516,6 @@ const HostGamePage: React.FC = () => {
               <div className="text-sm text-slate-400 mb-2">Host Controls</div>
             </div>
             <div className="flex gap-2 justify-center flex-wrap">
-              <Button
-                onClick={handleRevealAllAnswers}
-                variant="primary"
-                size="sm"
-                className="text-xs py-1 px-3"
-              >
-                👁️ Reveal All
-              </Button>
               <Button
                 onClick={handleForceNextQuestion}
                 variant="secondary"

--- a/frontend/src/pages/HostGamePage.tsx
+++ b/frontend/src/pages/HostGamePage.tsx
@@ -250,6 +250,12 @@ const HostGamePage: React.FC = () => {
       setControlMessage("All answers have been revealed!");
     });
 
+    socket.on("answer-overridden", (data) => {
+      console.log("✅ Answer overridden:", data);
+      setGame(data.game);
+      setControlMessage("Answer overridden by host.");
+    });
+
     socket.on("game-reset", (data) => {
       console.log("🔄 Game reset:", data);
       setGame(data.game);
@@ -330,6 +336,26 @@ const HostGamePage: React.FC = () => {
   const handleForceNextQuestion = () => {
     if (gameCode && socketRef.current) {
       socketRef.current.emit("force-next-question", { gameCode });
+    }
+  };
+
+  const handleOverrideAnswer = () => {
+    if (game && socketRef.current) {
+      const teamKey = game.gameState.currentTurn as "team1" | "team2";
+      const teamId = game.teams.find((t) =>
+        teamKey === "team1" ? t.id.includes("team1") : t.id.includes("team2")
+      )?.id;
+      if (!teamId) return;
+      const questionNumber = game.gameState.questionsAnswered[teamKey] + 1;
+      const points = 10; // simple override amount
+      socketRef.current.emit("override-answer", {
+        gameCode,
+        teamId,
+        round: game.currentRound,
+        questionNumber,
+        isCorrect: true,
+        pointsAwarded: points,
+      });
     }
   };
 
@@ -523,6 +549,14 @@ const HostGamePage: React.FC = () => {
                 className="text-xs py-1 px-3"
               >
                 ⏭️ Force Next
+              </Button>
+              <Button
+                onClick={handleOverrideAnswer}
+                variant="secondary"
+                size="sm"
+                className="text-xs py-1 px-3"
+              >
+                ✅ Override
               </Button>
               <Button
                 onClick={handleResetGame}

--- a/frontend/src/pages/HostGamePage.tsx
+++ b/frontend/src/pages/HostGamePage.tsx
@@ -30,6 +30,7 @@ const HostGamePage: React.FC = () => {
   const [isLoading, setIsLoading] = useState(false);
   const [controlMessage, setControlMessage] = useState<string>("");
   const [roundSummary, setRoundSummary] = useState<RoundSummary | null>(null);
+  const [overrideMode, setOverrideMode] = useState(false);
 
   const socketRef = useRef<Socket | null>(null);
 
@@ -248,12 +249,14 @@ const HostGamePage: React.FC = () => {
       console.log("👁️ All answers revealed:", data);
       setGame(data.game);
       setControlMessage("All answers have been revealed!");
+      setOverrideMode(false);
     });
 
     socket.on("answer-overridden", (data) => {
       console.log("✅ Answer overridden:", data);
       setGame(data.game);
       setControlMessage("Answer overridden by host.");
+      setOverrideMode(false);
     });
 
     socket.on("game-reset", (data) => {
@@ -261,6 +264,7 @@ const HostGamePage: React.FC = () => {
       setGame(data.game);
       setRoundSummary(null);
       setControlMessage(data.message || "Game has been reset.");
+      setOverrideMode(false);
     });
 
     socket.on("connect_error", (error) => {
@@ -340,6 +344,13 @@ const HostGamePage: React.FC = () => {
   };
 
   const handleOverrideAnswer = () => {
+    if (game) {
+      setOverrideMode(true);
+      setControlMessage("Select the correct answer");
+    }
+  };
+
+  const handleSelectOverride = (answerIndex: number) => {
     if (game && socketRef.current) {
       const teamKey = game.gameState.currentTurn as "team1" | "team2";
       const teamId = game.teams.find((t) =>
@@ -347,7 +358,10 @@ const HostGamePage: React.FC = () => {
       )?.id;
       if (!teamId) return;
       const questionNumber = game.gameState.questionsAnswered[teamKey] + 1;
-      const points = 10; // simple override amount
+      const answer = getCurrentQuestion(game).answers[answerIndex];
+      const points =
+        game.currentRound === 0 ? answer.score : answer.score * game.currentRound;
+
       socketRef.current.emit("override-answer", {
         gameCode,
         teamId,
@@ -355,7 +369,11 @@ const HostGamePage: React.FC = () => {
         questionNumber,
         isCorrect: true,
         pointsAwarded: points,
+        answerIndex,
       });
+
+      setOverrideMode(false);
+      setControlMessage("");
     }
   };
 
@@ -534,6 +552,8 @@ const HostGamePage: React.FC = () => {
             variant="host"
             isHost={true}
             controlMessage={controlMessage}
+            overrideMode={overrideMode}
+            onSelectAnswer={handleSelectOverride}
           />
 
           {/* Host Controls - CLEAN VERSION */}

--- a/frontend/src/pages/JoinGamePage.tsx
+++ b/frontend/src/pages/JoinGamePage.tsx
@@ -238,6 +238,11 @@ const JoinGamePage: React.FC = () => {
       setGame(data.game);
       setGameMessage("All answers have been revealed!");
     },
+    onAnswerOverridden: (data: any) => {
+      console.log("Answer overridden:", data);
+      setGame(data.game);
+      setGameMessage("Answer overridden by host.");
+    },
     onGameReset: (data: any) => {
       console.log("Game reset received:", data);
       setGame(data.game);

--- a/frontend/src/pages/JoinGamePage.tsx
+++ b/frontend/src/pages/JoinGamePage.tsx
@@ -266,7 +266,7 @@ const JoinGamePage: React.FC = () => {
     return () => {
       if (interval) clearInterval(interval);
     };
-  }, [game?.code, player?.id, requestPlayersList]);
+  }, [game, player, requestPlayersList]);
 
   const joinGame = async () => {
     if (!gameCode.trim() || !playerName.trim()) {

--- a/frontend/src/pages/JoinGamePage.tsx
+++ b/frontend/src/pages/JoinGamePage.tsx
@@ -161,6 +161,11 @@ const JoinGamePage: React.FC = () => {
           setGameMessage("Moving to next question.");
         }
       },
+      onQuestionComplete: (data: any) => {
+        console.log("Question complete event received:", data);
+        setGame(data.game);
+        setGameMessage("Waiting for host to advance...");
+      },
       onRoundComplete: (data: any) => {
         console.log("Round complete event received:", data);
 

--- a/frontend/src/pages/JoinGamePage.tsx
+++ b/frontend/src/pages/JoinGamePage.tsx
@@ -233,6 +233,17 @@ const JoinGamePage: React.FC = () => {
       }
       if (player?.id === data.playerId) setHasBuzzed(true);
     },
+    onAnswersRevealed: (data: any) => {
+      console.log("All answers revealed:", data);
+      setGame(data.game);
+      setGameMessage("All answers have been revealed!");
+    },
+    onGameReset: (data: any) => {
+      console.log("Game reset received:", data);
+      setGame(data.game);
+      setRoundSummary(null);
+      setGameMessage(data.message || "Game has been reset.");
+    },
   });
 
   // Periodically request updated player list from server

--- a/frontend/src/utils/gameHelper.ts
+++ b/frontend/src/utils/gameHelper.ts
@@ -96,6 +96,33 @@ export const getTeamColorClasses = (teamIndex: number) => {
 };
 
 // Validate answer match
+export const levenshtein = (a: string, b: string): number => {
+  const matrix = [] as number[][];
+
+  for (let i = 0; i <= b.length; i++) {
+    matrix[i] = [i];
+  }
+  for (let j = 0; j <= a.length; j++) {
+    matrix[0][j] = j;
+  }
+
+  for (let i = 1; i <= b.length; i++) {
+    for (let j = 1; j <= a.length; j++) {
+      if (b.charAt(i - 1) === a.charAt(j - 1)) {
+        matrix[i][j] = matrix[i - 1][j - 1];
+      } else {
+        matrix[i][j] = Math.min(
+          matrix[i - 1][j] + 1,
+          matrix[i][j - 1] + 1,
+          matrix[i - 1][j - 1] + 1
+        );
+      }
+    }
+  }
+
+  return matrix[b.length][a.length];
+};
+
 export const isAnswerMatch = (
   userAnswer: string,
   correctAnswer: string
@@ -103,9 +130,14 @@ export const isAnswerMatch = (
   const normalizedUser = userAnswer.toLowerCase().trim();
   const normalizedCorrect = correctAnswer.toLowerCase();
 
+  const distance = levenshtein(normalizedUser, normalizedCorrect);
+  const ratio = distance / Math.max(normalizedUser.length, normalizedCorrect.length);
+
   return (
     normalizedCorrect.includes(normalizedUser) ||
-    normalizedUser.includes(normalizedCorrect)
+    normalizedUser.includes(normalizedCorrect) ||
+    distance <= 2 ||
+    ratio <= 0.2
   );
 };
 

--- a/frontend/src/utils/gameHelper.ts
+++ b/frontend/src/utils/gameHelper.ts
@@ -17,6 +17,10 @@ export const getCurrentQuestion = (game: Game | null): Question | null => {
   return null;
 };
 
+export const formatRoundLabel = (round: number): string => {
+  return round === 0 ? "Toss-up Round" : `Round ${round}`;
+};
+
 // Format timer display
 export const formatTimer = (seconds: number): string => {
   const minutes = Math.floor(seconds / 60);

--- a/frontend/src/utils/gameHelper.ts
+++ b/frontend/src/utils/gameHelper.ts
@@ -133,12 +133,7 @@ export const isAnswerMatch = (
   const distance = levenshtein(normalizedUser, normalizedCorrect);
   const ratio = distance / Math.max(normalizedUser.length, normalizedCorrect.length);
 
-  return (
-    normalizedCorrect.includes(normalizedUser) ||
-    normalizedUser.includes(normalizedCorrect) ||
-    distance <= 2 ||
-    ratio <= 0.2
-  );
+  return distance <= 2 && ratio <= 0.25;
 };
 
 // Calculate points with round multiplier

--- a/frontend/src/utils/gameHelper.ts
+++ b/frontend/src/utils/gameHelper.ts
@@ -132,8 +132,9 @@ export const isAnswerMatch = (
 
   const distance = levenshtein(normalizedUser, normalizedCorrect);
   const ratio = distance / Math.max(normalizedUser.length, normalizedCorrect.length);
+  const allowed = Math.max(1, Math.floor(normalizedCorrect.length * 0.25));
 
-  return distance <= 2 && ratio <= 0.25;
+  return distance <= allowed && ratio <= 0.25;
 };
 
 // Calculate points with round multiplier

--- a/server/config/constants.js
+++ b/server/config/constants.js
@@ -39,6 +39,8 @@ const SOCKET_EVENTS = {
   NEXT_QUESTION: "next-question",
   FORCE_NEXT_QUESTION: "force-next-question",
   QUESTION_FORCED: "question-forced",
+  OVERRIDE_ANSWER: "override-answer",
+  ANSWER_OVERRIDDEN: "answer-overridden",
   CONTINUE_TO_NEXT_ROUND: "continue-to-next-round",
   ROUND_STARTED: "round-started",
   ROUND_COMPLETE: "round-complete",

--- a/server/config/constants.js
+++ b/server/config/constants.js
@@ -37,6 +37,7 @@ const SOCKET_EVENTS = {
   CLEAR_BUZZER: "clear-buzzer",
   BUZZER_CLEARED: "buzzer-cleared",
   NEXT_QUESTION: "next-question",
+  ADVANCE_QUESTION: "advance-question",
   FORCE_NEXT_QUESTION: "force-next-question",
   QUESTION_FORCED: "question-forced",
   OVERRIDE_ANSWER: "override-answer",
@@ -61,6 +62,7 @@ const SOCKET_EVENTS = {
 
   // Game events
   GAME_OVER: "game-over",
+  QUESTION_COMPLETE: "question-complete",
   GET_PLAYERS: "get-players",
   PLAYERS_LIST: "players-list",
   GET_GAME_STATE: "get-game-state",

--- a/server/config/constants.js
+++ b/server/config/constants.js
@@ -29,7 +29,6 @@ const SOCKET_EVENTS = {
   GAME_STARTED: "game-started",
   REVEAL_ANSWER: "reveal-answer",
   ANSWER_REVEALED: "answer-revealed",
-  REVEAL_ALL_ANSWERS: "reveal-all-answers",
   ANSWERS_REVEALED: "answers-revealed",
   AWARD_POINTS: "award-points",
   POINTS_AWARDED: "points-awarded",

--- a/server/services/gameService.js
+++ b/server/services/gameService.js
@@ -723,12 +723,7 @@ export function checkAnswerMatch(userAnswer, correctAnswers) {
     const distance = levenshtein(normalizedUser, normalizedCorrect);
     const ratio = distance / Math.max(normalizedUser.length, normalizedCorrect.length);
 
-    return (
-      normalizedCorrect.includes(normalizedUser) ||
-      normalizedUser.includes(normalizedCorrect) ||
-      distance <= 2 ||
-      ratio <= 0.2
-    );
+    return distance <= 2 && ratio <= 0.25;
   });
 }
 

--- a/server/services/gameService.js
+++ b/server/services/gameService.js
@@ -371,6 +371,7 @@ export function updateQuestionData(
     game.gameState.questionData[teamKey][roundKey][questionIndex].pointsEarned =
       points;
   }
+}
 
 // Override question data in game state (host override)
 export function overrideQuestionData(game, teamKey, round, questionNumber, isCorrect, points) {
@@ -748,8 +749,9 @@ export function checkAnswerMatch(userAnswer, correctAnswers) {
 
     const distance = levenshtein(normalizedUser, normalizedCorrect);
     const ratio = distance / Math.max(normalizedUser.length, normalizedCorrect.length);
+    const allowed = Math.max(1, Math.floor(normalizedCorrect.length * 0.25));
 
-    return distance <= 2 && ratio <= 0.25;
+    return distance <= allowed && ratio <= 0.25;
   });
 }
 

--- a/server/services/gameService.js
+++ b/server/services/gameService.js
@@ -384,7 +384,15 @@ export function overrideQuestionData(game, teamKey, round, questionNumber, isCor
 }
 
 // Host override an answer after submission
-export function overrideAnswer(gameCode, teamId, round, questionNumber, isCorrect, points) {
+export function overrideAnswer(
+  gameCode,
+  teamId,
+  round,
+  questionNumber,
+  isCorrect,
+  points,
+  answerIndex
+) {
   const game = games[gameCode];
   if (!game) return { success: false, message: "Game not found" };
   const team = game.teams.find((t) => t.id === teamId);
@@ -395,6 +403,20 @@ export function overrideAnswer(gameCode, teamId, round, questionNumber, isCorrec
   team.score += diff;
   team.currentRoundScore += diff;
   overrideQuestionData(game, teamKey, round, questionNumber, isCorrect, points);
+
+  // Reveal the specified answer if provided
+  if (typeof answerIndex === "number") {
+    const question = game.questions.find(
+      (q) =>
+        q.teamAssignment === teamKey &&
+        q.round === round &&
+        q.questionNumber === questionNumber
+    );
+    if (question && question.answers[answerIndex]) {
+      question.answers[answerIndex].revealed = true;
+    }
+  }
+
   updateGame(gameCode, game);
   return { success: true, game, teamId, teamName: team.name, round, questionNumber, pointsAwarded: points, isCorrect };
 }

--- a/server/services/gameService.js
+++ b/server/services/gameService.js
@@ -685,15 +685,51 @@ export function updatePlayer(playerId, updates) {
 }
 
 // Check if answer matches any correct answer
+// Simple Levenshtein distance implementation
+function levenshtein(a, b) {
+  const matrix = [];
+
+  for (let i = 0; i <= b.length; i++) {
+    matrix[i] = [i];
+  }
+  for (let j = 0; j <= a.length; j++) {
+    matrix[0][j] = j;
+  }
+
+  for (let i = 1; i <= b.length; i++) {
+    for (let j = 1; j <= a.length; j++) {
+      if (b.charAt(i - 1) === a.charAt(j - 1)) {
+        matrix[i][j] = matrix[i - 1][j - 1];
+      } else {
+        matrix[i][j] = Math.min(
+          matrix[i - 1][j] + 1,
+          matrix[i][j - 1] + 1,
+          matrix[i - 1][j - 1] + 1
+        );
+      }
+    }
+  }
+
+  return matrix[b.length][a.length];
+}
+
 export function checkAnswerMatch(userAnswer, correctAnswers) {
   const normalizedUser = userAnswer.toLowerCase().trim();
 
-  return correctAnswers.find(
-    (answer) =>
-      !answer.revealed &&
-      (answer.answer.toLowerCase().includes(normalizedUser) ||
-        normalizedUser.includes(answer.answer.toLowerCase()))
-  );
+  return correctAnswers.find((answer) => {
+    if (answer.revealed) return false;
+    const normalizedCorrect = answer.answer.toLowerCase();
+
+    const distance = levenshtein(normalizedUser, normalizedCorrect);
+    const ratio = distance / Math.max(normalizedUser.length, normalizedCorrect.length);
+
+    return (
+      normalizedCorrect.includes(normalizedUser) ||
+      normalizedUser.includes(normalizedCorrect) ||
+      distance <= 2 ||
+      ratio <= 0.2
+    );
+  });
 }
 
 // Get team by assignment string

--- a/server/services/gameService.js
+++ b/server/services/gameService.js
@@ -371,7 +371,33 @@ export function updateQuestionData(
     game.gameState.questionData[teamKey][roundKey][questionIndex].pointsEarned =
       points;
   }
+
+// Override question data in game state (host override)
+export function overrideQuestionData(game, teamKey, round, questionNumber, isCorrect, points) {
+  const roundKey = `round${round}`;
+  const questionIndex = questionNumber - 1;
+  if (game.gameState.questionData[teamKey] && game.gameState.questionData[teamKey][roundKey] && game.gameState.questionData[teamKey][roundKey][questionIndex]) {
+    game.gameState.questionData[teamKey][roundKey][questionIndex].firstAttemptCorrect = isCorrect;
+    game.gameState.questionData[teamKey][roundKey][questionIndex].pointsEarned = points;
+  }
 }
+
+// Host override an answer after submission
+export function overrideAnswer(gameCode, teamId, round, questionNumber, isCorrect, points) {
+  const game = games[gameCode];
+  if (!game) return { success: false, message: "Game not found" };
+  const team = game.teams.find((t) => t.id === teamId);
+  if (!team) return { success: false, message: "Team not found" };
+  const teamKey = teamId.includes("team1") ? "team1" : "team2";
+  const currentPoints = game.gameState.questionData?.[teamKey]?.[`round${round}`]?.[questionNumber - 1]?.pointsEarned || 0;
+  const diff = points - currentPoints;
+  team.score += diff;
+  team.currentRoundScore += diff;
+  overrideQuestionData(game, teamKey, round, questionNumber, isCorrect, points);
+  updateGame(gameCode, game);
+  return { success: true, game, teamId, teamName: team.name, round, questionNumber, pointsAwarded: points, isCorrect };
+}
+
 
 // Submit an answer - UPDATED: Single attempt system
 export function submitAnswer(gameCode, playerId, answerText) {

--- a/server/services/gameService.js
+++ b/server/services/gameService.js
@@ -195,6 +195,7 @@ function startNewRound(game) {
   game.currentRound += 1;
   game.gameState.questionsAnswered.team1 = 0;
   game.gameState.questionsAnswered.team2 = 0;
+  game.gameState.canAdvance = false;
 
   // Determine which team should start this round.
   // By default team1 would start, but after the toss-up the winning team
@@ -322,6 +323,7 @@ export function startGame(gameCode) {
   game.status = "active";
   game.gameState.currentTurn = "team1"; // Team 1 starts
   game.gameState.awaitingAnswer = true;
+  game.gameState.canAdvance = false;
 
   // Set to first question (should be team1's first question)
   const firstQuestion = game.questions.find(
@@ -676,6 +678,7 @@ export function continueToNextRound(gameCode) {
     startNewRound(game);
     game.status = "active";
     game.gameState.awaitingAnswer = true;
+    game.gameState.canAdvance = false;
   } else {
     game.status = "finished";
   }

--- a/server/services/gameService.js
+++ b/server/services/gameService.js
@@ -74,8 +74,8 @@ export function getNextQuestionIndex(game) {
   if (!currentQuestion) return game.currentQuestionIndex;
 
   const currentTeam = game.gameState.currentTurn;
-  const questionsAnswered = game.gameState.questionsAnswered[currentTeam];
   const otherTeam = currentTeam === "team1" ? "team2" : "team1";
+  const questionsAnswered = game.gameState.questionsAnswered[currentTeam];
 
   // If current team has answered all 3 questions, switch to other team
   if (questionsAnswered >= 3) {
@@ -212,14 +212,17 @@ function startNewRound(game) {
     team.currentRoundScore = 0;
   });
 
-  // Set to first question of new round for team1
-  const team1FirstQuestion = game.questions.find(
-    (q) => q.teamAssignment === "team1" && q.round === game.currentRound
+  // Set to first question of new round for the starting team
+  const firstQuestion = game.questions.find(
+    (q) =>
+      q.teamAssignment === startingTeam &&
+      q.round === game.currentRound &&
+      q.questionNumber === 1
   );
 
-  if (team1FirstQuestion) {
+  if (firstQuestion) {
     game.currentQuestionIndex = game.questions.findIndex(
-      (q) => q._id === team1FirstQuestion._id
+      (q) => q._id === firstQuestion._id
     );
   }
 
@@ -536,38 +539,54 @@ export function advanceGameState(gameCode) {
   if (!game) return null;
 
   const currentTeam = game.gameState.currentTurn;
+  const otherTeam = currentTeam === "team1" ? "team2" : "team1";
 
   // Increment questions answered count
   game.gameState.questionsAnswered[currentTeam] += 1;
 
-  // Check if team has answered all 3 questions
+  // Check if the current team has answered all 3 questions
   if (game.gameState.questionsAnswered[currentTeam] >= 3) {
-    if (currentTeam === "team1") {
-      // Switch to team 2
-      game.gameState.currentTurn = "team2";
+    if (game.gameState.questionsAnswered[otherTeam] < 3) {
+      // Switch to the other team
+      game.gameState.currentTurn = otherTeam;
       updateTeamActiveStatus(game);
 
-      // Find team2's first question for current round
-      const team2FirstQuestion = game.questions.find(
+      // Jump to the other team's next unanswered question
+      const questionNumber = game.gameState.questionsAnswered[otherTeam] + 1;
+      const nextQuestion = game.questions.find(
         (q) =>
-          q.teamAssignment === "team2" &&
+          q.teamAssignment === otherTeam &&
           q.round === game.currentRound &&
-          q.questionNumber === 1
+          q.questionNumber === questionNumber
       );
 
-      if (team2FirstQuestion) {
+      if (nextQuestion) {
         game.currentQuestionIndex = game.questions.findIndex(
-          (q) => q._id === team2FirstQuestion._id
+          (q) => q._id === nextQuestion._id
         );
       }
     } else {
-      // Team 2 finished - round complete
+      // Both teams finished - round complete
       if (game.currentRound < 3) {
         game.status = "round-summary";
         game.gameState.currentTurn = null;
         updateTeamActiveStatus(game);
       } else {
         // Game finished
+        const roundKey = `round${game.currentRound}`;
+        const team1 = game.teams.find((t) => t.id.includes("team1"));
+        const team2 = game.teams.find((t) => t.id.includes("team2"));
+
+        if (team1 && team2) {
+          game.gameState.roundScores[roundKey] = {
+            team1: team1.currentRoundScore,
+            team2: team2.currentRoundScore,
+          };
+
+          team1.roundScores[game.currentRound - 1] = team1.currentRoundScore;
+          team2.roundScores[game.currentRound - 1] = team2.currentRoundScore;
+        }
+
         game.status = "finished";
         game.gameState.currentTurn = null;
         updateTeamActiveStatus(game);

--- a/server/services/gameService.js
+++ b/server/services/gameService.js
@@ -321,20 +321,23 @@ export function startGame(gameCode) {
   if (!game) return null;
 
   game.status = "active";
-  game.gameState.currentTurn = "team1"; // Team 1 starts
   game.gameState.awaitingAnswer = true;
   game.gameState.canAdvance = false;
 
-  // Set to first question (should be team1's first question)
-  const firstQuestion = game.questions.find(
-    (q) =>
-      q.teamAssignment === "team1" && q.round === 1 && q.questionNumber === 1
-  );
+  if (game.currentRound === 0) {
+    game.gameState.currentTurn = null;
+  } else {
+    game.gameState.currentTurn = "team1";
 
-  if (firstQuestion) {
-    game.currentQuestionIndex = game.questions.findIndex(
-      (q) => q._id === firstQuestion._id
+    const firstQuestion = game.questions.find(
+      (q) => q.teamAssignment === "team1" && q.round === 1 && q.questionNumber === 1
     );
+
+    if (firstQuestion) {
+      game.currentQuestionIndex = game.questions.findIndex(
+        (q) => q._id === firstQuestion._id
+      );
+    }
   }
 
   updateTeamActiveStatus(game);

--- a/server/socket/hostEvents.js
+++ b/server/socket/hostEvents.js
@@ -202,6 +202,31 @@ export function setupHostEvents(socket, io) {
     }
   });
 
+  // Host advances to the next question after a question is completed
+  socket.on("advance-question", (data) => {
+    const { gameCode } = data;
+    const game = getGame(gameCode);
+
+    if (
+      game &&
+      game.hostId === socket.id &&
+      game.status === "active" &&
+      game.gameState.canAdvance
+    ) {
+      const advancedGame = advanceGameState(gameCode);
+      if (advancedGame) {
+        // Reset advancement flag
+        advancedGame.gameState.canAdvance = false;
+        updateGame(gameCode, advancedGame);
+
+        handleGameStateAdvancement(gameCode, advancedGame, io, {
+          game: advancedGame,
+          teamName: "Host",
+        });
+      }
+    }
+  });
+
   // Manual round summary (emergency override)
   socket.on("force-round-summary", (data) => {
     const { gameCode } = data;

--- a/server/socket/hostEvents.js
+++ b/server/socket/hostEvents.js
@@ -264,6 +264,13 @@ export function setupHostEvents(socket, io) {
         },
       };
 
+      // Ensure the copied toss-up question has all answers hidden
+      if (resetUpdates.gameState.tossUpQuestion) {
+        resetUpdates.gameState.tossUpQuestion.answers.forEach(
+          (a) => (a.revealed = false)
+        );
+      }
+
       game.buzzedTeamId = null;
       game.activeTeamId = null;
       game.tossUpWinner = null;

--- a/server/socket/hostEvents.js
+++ b/server/socket/hostEvents.js
@@ -127,12 +127,14 @@ export function setupHostEvents(socket, io) {
           console.log(`🆕 Round ${updatedGame.currentRound} started`);
         } else if (updatedGame.status === "finished") {
           // Game finished after round 3
-          const { getGameWinner } = require("../services/gameService");
+          const { getGameWinner, calculateRoundSummary } = require("../services/gameService.js");
           const winner = getGameWinner(updatedGame);
+          const roundSummary = calculateRoundSummary(updatedGame);
 
           io.to(gameCode).emit("game-over", {
             game: updatedGame,
             winner: winner,
+            roundSummary,
           });
 
           console.log(`🏆 Game finished after all rounds: ${gameCode}`);

--- a/server/socket/hostEvents.js
+++ b/server/socket/hostEvents.js
@@ -158,8 +158,7 @@ export function setupHostEvents(socket, io) {
 
         // Record skipped question as incorrect
         const teamKey = game.gameState.currentTurn;
-        const questionNumber =
-          game.gameState.questionsAnswered[teamKey] + 1;
+        const questionNumber = game.gameState.questionsAnswered[teamKey] + 1;
         updateQuestionData(
           game,
           teamKey,
@@ -169,6 +168,9 @@ export function setupHostEvents(socket, io) {
           0
         );
 
+        // Allow host to advance manually
+        game.gameState.canAdvance = true;
+
         updateGame(gameCode, game);
 
         io.to(gameCode).emit("answers-revealed", {
@@ -177,27 +179,12 @@ export function setupHostEvents(socket, io) {
           byHost: true,
         });
 
-        // Wait a moment so players can see the revealed answers
-        setTimeout(() => {
-          const advancedGame = advanceGameState(gameCode);
-          if (advancedGame) {
-            handleGameStateAdvancement(gameCode, advancedGame, io, {
-              teamName: "Host",
-              game,
-            });
+        io.to(gameCode).emit("question-complete", {
+          game,
+          currentQuestion,
+        });
 
-            io.to(gameCode).emit("question-forced", {
-              game: advancedGame,
-              currentQuestion: getCurrentQuestion(advancedGame),
-              activeTeam: advancedGame.gameState.currentTurn,
-              byHost: true,
-            });
-
-            console.log(
-              `⚠️ Host forced advance to question ${advancedGame.currentQuestionIndex + 1}`
-            );
-          }
-        }, 2000);
+        console.log(`⚠️ Host revealed all answers for question ${game.currentQuestionIndex + 1}`);
       }
     }
   });

--- a/server/socket/hostEvents.js
+++ b/server/socket/hostEvents.js
@@ -243,6 +243,7 @@ export function setupHostEvents(socket, io) {
         currentQuestionIndex: 0,
         currentRound: 0,
         gameState: {
+          ...game.gameState,
           currentTurn: null,
           questionsAnswered: { team1: 0, team2: 0 },
           roundScores: {
@@ -255,6 +256,11 @@ export function setupHostEvents(socket, io) {
           currentQuestionAttempts: 0,
           maxAttemptsPerQuestion: 3,
           questionData: initializeQuestionData(), // Reset question data
+          tossUpQuestion: game.gameState.tossUpQuestion
+            ? JSON.parse(JSON.stringify(game.gameState.tossUpQuestion))
+            : undefined,
+          tossUpAnswers: [],
+          tossUpSubmittedTeams: [],
         },
       };
 

--- a/server/socket/hostEvents.js
+++ b/server/socket/hostEvents.js
@@ -8,6 +8,7 @@ import {
   initializeQuestionData,
   updateQuestionData,
   advanceGameState,
+  overrideAnswer,
 } from "../services/gameService.js";
 import { handleGameStateAdvancement } from "./playerEvents.js";
 
@@ -226,6 +227,29 @@ export function setupHostEvents(socket, io) {
       console.log(
         `⚠️ Host forced round summary for round ${game.currentRound}`
       );
+    }
+  });
+
+  // Host overrides a player's answer
+  socket.on("override-answer", (data) => {
+    const { gameCode, teamId, round, questionNumber, isCorrect, pointsAwarded } = data;
+    const game = getGame(gameCode);
+
+    if (game && game.hostId === socket.id) {
+      const result = overrideAnswer(
+        gameCode,
+        teamId,
+        round,
+        questionNumber,
+        isCorrect,
+        pointsAwarded
+      );
+
+      if (result.success) {
+        io.to(gameCode).emit("answer-overridden", result);
+      } else {
+        socket.emit("error", { message: result.message });
+      }
     }
   });
 

--- a/server/socket/hostEvents.js
+++ b/server/socket/hostEvents.js
@@ -9,6 +9,7 @@ import {
   updateQuestionData,
   advanceGameState,
   overrideAnswer,
+  getGameWinner,
 } from "../services/gameService.js";
 import { handleGameStateAdvancement } from "./playerEvents.js";
 
@@ -127,7 +128,6 @@ export function setupHostEvents(socket, io) {
           console.log(`🆕 Round ${updatedGame.currentRound} started`);
         } else if (updatedGame.status === "finished") {
           // Game finished after round 3
-          const { getGameWinner, calculateRoundSummary } = require("../services/gameService.js");
           const winner = getGameWinner(updatedGame);
           const roundSummary = calculateRoundSummary(updatedGame);
 
@@ -234,7 +234,7 @@ export function setupHostEvents(socket, io) {
 
   // Host overrides a player's answer
   socket.on("override-answer", (data) => {
-    const { gameCode, teamId, round, questionNumber, isCorrect, pointsAwarded } = data;
+    const { gameCode, teamId, round, questionNumber, isCorrect, pointsAwarded, answerIndex } = data;
     const game = getGame(gameCode);
 
     if (game && game.hostId === socket.id) {
@@ -244,7 +244,8 @@ export function setupHostEvents(socket, io) {
         round,
         questionNumber,
         isCorrect,
-        pointsAwarded
+        pointsAwarded,
+        answerIndex
       );
 
       if (result.success) {

--- a/server/socket/hostEvents.js
+++ b/server/socket/hostEvents.js
@@ -6,7 +6,10 @@ import {
   getCurrentQuestion,
   calculateRoundSummary,
   initializeQuestionData,
+  updateQuestionData,
+  advanceGameState,
 } from "../services/gameService.js";
+import { handleGameStateAdvancement } from "./playerEvents.js";
 
 export function setupHostEvents(socket, io) {
   // Host joins game
@@ -98,37 +101,6 @@ export function setupHostEvents(socket, io) {
     }
   });
 
-  // Reveal all answers for the current question
-  socket.on("reveal-all-answers", (data) => {
-    const { gameCode } = data;
-    const game = getGame(gameCode);
-
-    if (game && game.hostId === socket.id && game.status === "active") {
-      console.log(`⚠️ Host revealing all answers in game: ${gameCode}`);
-
-      const currentQuestion = getCurrentQuestion(game);
-      if (currentQuestion) {
-        // Reveal all answers
-        currentQuestion.answers.forEach((answer) => {
-          answer.revealed = true;
-        });
-
-        const updatedGame = updateGame(gameCode, game);
-
-        io.to(gameCode).emit("answers-revealed", {
-          game: updatedGame,
-          currentQuestion: currentQuestion,
-          byHost: true,
-        });
-
-        console.log(
-          `⚠️ All answers revealed for question ${
-            game.currentQuestionIndex + 1
-          }`
-        );
-      }
-    }
-  });
 
   // Continue to next round (from round summary screen)
   socket.on("continue-to-next-round", (data) => {
@@ -176,37 +148,49 @@ export function setupHostEvents(socket, io) {
     if (game && game.hostId === socket.id && game.status === "active") {
       console.log(`⚠️ Host forcing next question in game: ${gameCode}`);
 
-      // Manually advance question index
-      game.currentQuestionIndex += 1;
-
-      // Update turn logic
       const currentQuestion = getCurrentQuestion(game);
       if (currentQuestion) {
-        game.gameState.currentTurn = currentQuestion.teamAssignment;
+        // Reveal all answers
+        currentQuestion.answers.forEach((a) => (a.revealed = true));
 
-        // Update team active status
-        game.teams.forEach((team) => {
-          if (currentQuestion.teamAssignment === "team1") {
-            team.active = team.id.includes("team1") || team.name.includes("1");
-          } else {
-            team.active = team.id.includes("team2") || team.name.includes("2");
-          }
+        // Record skipped question as incorrect
+        const teamKey = game.gameState.currentTurn;
+        const questionNumber =
+          game.gameState.questionsAnswered[teamKey] + 1;
+        updateQuestionData(
+          game,
+          teamKey,
+          game.currentRound,
+          questionNumber,
+          false,
+          0
+        );
+
+        updateGame(gameCode, game);
+
+        io.to(gameCode).emit("answers-revealed", {
+          game,
+          currentQuestion,
+          byHost: true,
+        });
+      }
+
+      const advancedGame = advanceGameState(gameCode);
+      if (advancedGame) {
+        handleGameStateAdvancement(gameCode, advancedGame, io, {
+          teamName: "Host", // placeholder
+          game,
         });
 
-        // Reset attempts for forced question
-        game.gameState.currentQuestionAttempts = 0;
-
-        const updatedGame = updateGame(gameCode, game);
-
         io.to(gameCode).emit("question-forced", {
-          game: updatedGame,
-          currentQuestion: currentQuestion,
-          activeTeam: game.gameState.currentTurn,
+          game: advancedGame,
+          currentQuestion: getCurrentQuestion(advancedGame),
+          activeTeam: advancedGame.gameState.currentTurn,
           byHost: true,
         });
 
         console.log(
-          `⚠️ Host forced advance to question ${game.currentQuestionIndex + 1}`
+          `⚠️ Host forced advance to question ${advancedGame.currentQuestionIndex + 1}`
         );
       }
     }
@@ -254,7 +238,7 @@ export function setupHostEvents(socket, io) {
       const resetUpdates = {
         status: "waiting",
         currentQuestionIndex: 0,
-        currentRound: 1,
+        currentRound: 0,
         gameState: {
           currentTurn: null,
           questionsAnswered: { team1: 0, team2: 0 },
@@ -270,6 +254,12 @@ export function setupHostEvents(socket, io) {
           questionData: initializeQuestionData(), // Reset question data
         },
       };
+
+      game.buzzedTeamId = null;
+      game.activeTeamId = null;
+      game.tossUpWinner = null;
+      game.tossUpAnswers = [];
+      game.tossUpSubmittedTeams = [];
 
       // Reset team scores and states
       game.teams.forEach((team) => {

--- a/server/socket/hostEvents.js
+++ b/server/socket/hostEvents.js
@@ -173,25 +173,28 @@ export function setupHostEvents(socket, io) {
           currentQuestion,
           byHost: true,
         });
-      }
 
-      const advancedGame = advanceGameState(gameCode);
-      if (advancedGame) {
-        handleGameStateAdvancement(gameCode, advancedGame, io, {
-          teamName: "Host", // placeholder
-          game,
-        });
+        // Wait a moment so players can see the revealed answers
+        setTimeout(() => {
+          const advancedGame = advanceGameState(gameCode);
+          if (advancedGame) {
+            handleGameStateAdvancement(gameCode, advancedGame, io, {
+              teamName: "Host",
+              game,
+            });
 
-        io.to(gameCode).emit("question-forced", {
-          game: advancedGame,
-          currentQuestion: getCurrentQuestion(advancedGame),
-          activeTeam: advancedGame.gameState.currentTurn,
-          byHost: true,
-        });
+            io.to(gameCode).emit("question-forced", {
+              game: advancedGame,
+              currentQuestion: getCurrentQuestion(advancedGame),
+              activeTeam: advancedGame.gameState.currentTurn,
+              byHost: true,
+            });
 
-        console.log(
-          `⚠️ Host forced advance to question ${advancedGame.currentQuestionIndex + 1}`
-        );
+            console.log(
+              `⚠️ Host forced advance to question ${advancedGame.currentQuestionIndex + 1}`
+            );
+          }
+        }, 2000);
       }
     }
   });
@@ -276,12 +279,28 @@ export function setupHostEvents(socket, io) {
         });
       });
 
+      if (game.gameState.tossUpQuestion) {
+        game.gameState.tossUpQuestion.answers.forEach(
+          (a) => (a.revealed = false)
+        );
+      }
+
       const resetGame = updateGame(gameCode, resetUpdates);
 
       io.to(gameCode).emit("game-reset", {
         game: resetGame,
         message: "Game has been reset by the host",
       });
+
+      // Automatically restart the game so play can resume without creating a new code
+      const startedGame = startGame(gameCode);
+      if (startedGame) {
+        io.to(gameCode).emit("game-started", {
+          game: startedGame,
+          currentQuestion: getCurrentQuestion(startedGame),
+          activeTeam: startedGame.gameState.currentTurn,
+        });
+      }
 
       console.log(`🔄 Game reset successfully with question data: ${gameCode}`);
     }

--- a/server/socket/playerEvents.js
+++ b/server/socket/playerEvents.js
@@ -261,9 +261,15 @@ export function setupPlayerEvents(socket, io) {
           }
 
           setTimeout(() => {
-            const advancedGame = advanceGameState(gameCode);
-            if (advancedGame) {
-              handleGameStateAdvancement(gameCode, advancedGame, io, result);
+            const readyGame = getGame(gameCode);
+            if (readyGame) {
+              readyGame.gameState.canAdvance = true;
+              updateGame(gameCode, readyGame);
+
+              io.to(gameCode).emit("question-complete", {
+                game: readyGame,
+                currentQuestion: getCurrentQuestion(readyGame),
+              });
             }
           }, 3000);
         }, 2000);
@@ -277,9 +283,15 @@ export function setupPlayerEvents(socket, io) {
       });
 
       setTimeout(() => {
-        const advancedGame = advanceGameState(gameCode);
-        if (advancedGame) {
-          handleGameStateAdvancement(gameCode, advancedGame, io, result);
+        const readyGame = getGame(gameCode);
+        if (readyGame) {
+          readyGame.gameState.canAdvance = true;
+          updateGame(gameCode, readyGame);
+
+          io.to(gameCode).emit("question-complete", {
+            game: readyGame,
+            currentQuestion: getCurrentQuestion(readyGame),
+          });
         }
       }, 3000);
     }

--- a/server/socket/playerEvents.js
+++ b/server/socket/playerEvents.js
@@ -357,12 +357,14 @@ export function handleGameStateAdvancement(gameCode, advancedGame, io, result) {
 
     console.log(`🏁 Round ${advancedGame.currentRound} completed`);
   } else if (advancedGame.status === "finished") {
-    // Game finished
+    // Game finished - include round summary for final round
     const winner = getGameWinner(advancedGame);
+    const roundSummary = calculateRoundSummary(advancedGame);
 
     io.to(gameCode).emit("game-over", {
       game: advancedGame,
       winner: winner,
+      roundSummary,
     });
 
     console.log(`🏆 Game finished: ${gameCode}`);

--- a/server/utils/constants.js
+++ b/server/utils/constants.js
@@ -37,6 +37,7 @@ export const SOCKET_EVENTS = {
   CLEAR_BUZZER: "clear-buzzer",
   BUZZER_CLEARED: "buzzer-cleared",
   NEXT_QUESTION: "next-question",
+  ADVANCE_QUESTION: "advance-question",
   FORCE_NEXT_QUESTION: "force-next-question",
   QUESTION_FORCED: "question-forced",
   OVERRIDE_ANSWER: "override-answer",
@@ -61,6 +62,7 @@ export const SOCKET_EVENTS = {
 
   // Game events
   GAME_OVER: "game-over",
+  QUESTION_COMPLETE: "question-complete",
   GET_PLAYERS: "get-players",
   PLAYERS_LIST: "players-list",
   GET_GAME_STATE: "get-game-state",

--- a/server/utils/constants.js
+++ b/server/utils/constants.js
@@ -39,6 +39,8 @@ export const SOCKET_EVENTS = {
   NEXT_QUESTION: "next-question",
   FORCE_NEXT_QUESTION: "force-next-question",
   QUESTION_FORCED: "question-forced",
+  OVERRIDE_ANSWER: "override-answer",
+  ANSWER_OVERRIDDEN: "answer-overridden",
   CONTINUE_TO_NEXT_ROUND: "continue-to-next-round",
   ROUND_STARTED: "round-started",
   ROUND_COMPLETE: "round-complete",

--- a/server/utils/constants.js
+++ b/server/utils/constants.js
@@ -29,7 +29,6 @@ export const SOCKET_EVENTS = {
   GAME_STARTED: "game-started",
   REVEAL_ANSWER: "reveal-answer",
   ANSWER_REVEALED: "answer-revealed",
-  REVEAL_ALL_ANSWERS: "reveal-all-answers",
   ANSWERS_REVEALED: "answers-revealed",
   AWARD_POINTS: "award-points",
   POINTS_AWARDED: "points-awarded",

--- a/server/utils/gameUtils.js
+++ b/server/utils/gameUtils.js
@@ -6,13 +6,45 @@
  * @param {string} correctAnswer - Correct answer
  * @returns {boolean} - Whether the answers match
  */
+function levenshtein(a, b) {
+  const matrix = [];
+
+  for (let i = 0; i <= b.length; i++) {
+    matrix[i] = [i];
+  }
+  for (let j = 0; j <= a.length; j++) {
+    matrix[0][j] = j;
+  }
+
+  for (let i = 1; i <= b.length; i++) {
+    for (let j = 1; j <= a.length; j++) {
+      if (b.charAt(i - 1) === a.charAt(j - 1)) {
+        matrix[i][j] = matrix[i - 1][j - 1];
+      } else {
+        matrix[i][j] = Math.min(
+          matrix[i - 1][j] + 1,
+          matrix[i][j - 1] + 1,
+          matrix[i - 1][j - 1] + 1
+        );
+      }
+    }
+  }
+
+  return matrix[b.length][a.length];
+}
+
 function isAnswerMatch(userAnswer, correctAnswer) {
   const normalizedUser = userAnswer.toLowerCase().trim();
   const normalizedCorrect = correctAnswer.toLowerCase();
 
+  const distance = levenshtein(normalizedUser, normalizedCorrect);
+  const ratio = distance / Math.max(normalizedUser.length, normalizedCorrect.length);
+
   return (
     normalizedCorrect.includes(normalizedUser) ||
-    normalizedUser.includes(normalizedCorrect)
+    normalizedUser.includes(normalizedCorrect) ||
+    distance <= 2 ||
+    ratio <= 0.2
   );
 }
 

--- a/server/utils/gameUtils.js
+++ b/server/utils/gameUtils.js
@@ -40,12 +40,7 @@ function isAnswerMatch(userAnswer, correctAnswer) {
   const distance = levenshtein(normalizedUser, normalizedCorrect);
   const ratio = distance / Math.max(normalizedUser.length, normalizedCorrect.length);
 
-  return (
-    normalizedCorrect.includes(normalizedUser) ||
-    normalizedUser.includes(normalizedCorrect) ||
-    distance <= 2 ||
-    ratio <= 0.2
-  );
+  return distance <= 2 && ratio <= 0.25;
 }
 
 /**


### PR DESCRIPTION
## Summary
- remove unused "reveal all answers" handler and button
- show toss‑up question scores correctly
- reset game properly and listen for reset event

## Testing
- `npm test` in `server` *(fails: Error: no test specified)*
- `npm test` in `frontend` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_688793e1b2508331ba737fb9a2ad600e