### PR TITLE
Implement host override feature

### DIFF
--- a/frontend/src/components/game/GameBoard.tsx
+++ b/frontend/src/components/game/GameBoard.tsx
@@ -5,19 +5,23 @@ import { getCurrentQuestion } from "../../utils/gameHelper";
 interface GameBoardProps {
   game: Game;
   onRevealAnswer?: (answerIndex: number) => void;
+  onOverrideAnswer?: (answerIndex: number) => void;
   onNextQuestion?: () => void;
   isHost?: boolean;
   variant?: "host" | "player";
   controlMessage?: string;
+  showOverrideControls?: boolean;
 }
 
 const GameBoard: React.FC<GameBoardProps> = ({
   game,
   onRevealAnswer,
+  onOverrideAnswer,
   onNextQuestion,
   isHost = false,
   variant = "host",
   controlMessage,
+  showOverrideControls = false,
 }) => {
   const currentQuestion = getCurrentQuestion(game);
 
@@ -177,15 +181,26 @@ const GameBoard: React.FC<GameBoardProps> = ({
                 )
               )}
             </span>
-            <span
-              className={`answer-points ${
-                answer.revealed
-                  ? "bg-gradient-to-r from-yellow-400 to-orange-400 text-black"
-                  : "bg-slate-700 text-slate-400"
-              }`}
+          <span
+            className={`answer-points ${
+              answer.revealed
+                ? "bg-gradient-to-r from-yellow-400 to-orange-400 text-black"
+                : "bg-slate-700 text-slate-400"
+            }`}
+          >
+            {answer.revealed || isHost ? answer.score * game.currentRound : "?"}
+          </span>
+          {isHost && showOverrideControls && (
+            <button
+              className="ml-2 text-xs text-red-500"
+              onClick={(e) => {
+                e.stopPropagation();
+                onOverrideAnswer?.(index);
+              }}
             >
-              {answer.revealed || isHost ? answer.score * game.currentRound : "?"}
-            </span>
+              Override
+            </button>
+          )}
           </div>
         ))}
       </div>

--- a/frontend/src/hooks/useSocket.ts
+++ b/frontend/src/hooks/useSocket.ts
@@ -28,6 +28,7 @@ interface SocketCallbacks {
   onGameReset?: (data: any) => void;
   // NEW: Card revelation events
   onRemainingCardsRevealed?: (data: any) => void;
+  onAnswerOverridden?: (data: any) => void;
 }
 
 export const useSocket = (callbacks: SocketCallbacks = {}) => {
@@ -166,6 +167,10 @@ export const useSocket = (callbacks: SocketCallbacks = {}) => {
       newSocket.on("remaining-cards-revealed", callbacks.onRemainingCardsRevealed);
     }
 
+    if (callbacks.onAnswerOverridden) {
+      newSocket.on("answer-overridden", callbacks.onAnswerOverridden);
+    }
+
     socketRef.current = newSocket;
     setSocket(newSocket);
     return newSocket;
@@ -231,6 +236,20 @@ export const useSocket = (callbacks: SocketCallbacks = {}) => {
     }
   };
 
+  const overrideAnswer = (
+    gameCode: string,
+    answerIndex: number,
+    teamKey: string
+  ) => {
+    if (socketRef.current) {
+      socketRef.current.emit("override-answer", {
+        gameCode,
+        answerIndex,
+        teamKey,
+      });
+    }
+  };
+
   // Player actions
   const playerJoinGame = (gameCode: string, playerId: string) => {
     if (socketRef.current) {
@@ -281,6 +300,7 @@ export const useSocket = (callbacks: SocketCallbacks = {}) => {
     forceNextQuestion,
     forceRoundSummary,
     resetGame,
+    overrideAnswer,
     buzzIn,
     requestPlayersList,
     // Player actions

--- a/frontend/src/pages/HostGamePage.tsx
+++ b/frontend/src/pages/HostGamePage.tsx
@@ -30,6 +30,7 @@ const HostGamePage: React.FC = () => {
   const [isLoading, setIsLoading] = useState(false);
   const [controlMessage, setControlMessage] = useState<string>("");
   const [roundSummary, setRoundSummary] = useState<RoundSummary | null>(null);
+  const [showOverrideControls, setShowOverrideControls] = useState(false);
 
   const socketRef = useRef<Socket | null>(null);
 
@@ -146,6 +147,7 @@ const HostGamePage: React.FC = () => {
       setControlMessage(
         `✅ ${data.playerName} answered correctly! +${data.pointsAwarded} points for ${data.teamName}.`
       );
+      setShowOverrideControls(false);
     });
 
     socket.on("answer-incorrect", (data) => {
@@ -154,6 +156,7 @@ const HostGamePage: React.FC = () => {
       setControlMessage(
         `❌ ${data.playerName} answered incorrectly. ${data.message}`
       );
+      setShowOverrideControls(true);
     });
 
     socket.on("remaining-cards-revealed", (data) => {
@@ -166,6 +169,7 @@ const HostGamePage: React.FC = () => {
       console.log("↔️ Turn changed:", data);
       setGame(data.game);
       setControlMessage(`Turn switched to ${data.teamName}!`);
+      setShowOverrideControls(false);
     });
 
     socket.on("next-question", (data) => {
@@ -176,6 +180,7 @@ const HostGamePage: React.FC = () => {
       } else {
         setControlMessage(`Moving to next question.`);
       }
+      setShowOverrideControls(false);
     });
 
       socket.on("round-complete", (data) => {
@@ -186,8 +191,8 @@ const HostGamePage: React.FC = () => {
           setGame(data.game);
         }
 
-        if (data.roundSummary) {
-          setRoundSummary(data.roundSummary);
+      if (data.roundSummary) {
+        setRoundSummary(data.roundSummary);
           if (data.roundSummary.round === 0) {
             setControlMessage(
               `${data.roundSummary.tossUpWinner?.teamName || "A team"} won the toss-up!`
@@ -205,9 +210,10 @@ const HostGamePage: React.FC = () => {
             `Round ${data.round} completed! ${
               data.isGameFinished ? "Game finished!" : "Ready for next round."
             }`
-          );
-        }
-      });
+        );
+      }
+      setShowOverrideControls(false);
+    });
 
     socket.on("round-started", (data) => {
       console.log("🆕 New round started:", data);
@@ -218,6 +224,7 @@ const HostGamePage: React.FC = () => {
           data.activeTeam === "team1" ? "Team 1" : "Team 2"
         } goes first. Each question allows only 1 attempt.`
       );
+      setShowOverrideControls(false);
     });
 
     socket.on("game-over", (data) => {
@@ -248,6 +255,13 @@ const HostGamePage: React.FC = () => {
       console.log("👁️ All answers revealed:", data);
       setGame(data.game);
       setControlMessage("All answers have been revealed!");
+    });
+
+    socket.on("answer-overridden", (data) => {
+      console.log("✅ Answer overridden:", data);
+      setGame(data.game);
+      setControlMessage("Answer overridden by host.");
+      setShowOverrideControls(false);
     });
 
     socket.on("connect_error", (error) => {
@@ -336,6 +350,18 @@ const HostGamePage: React.FC = () => {
   const handleResetGame = () => {
     if (gameCode && socketRef.current) {
       socketRef.current.emit("reset-game", { gameCode });
+    }
+  };
+
+  const handleOverrideAnswer = (answerIndex: number) => {
+    if (gameCode && socketRef.current && game) {
+      const teamKey = game.gameState.currentTurn as "team1" | "team2";
+      socketRef.current.emit("override-answer", {
+        gameCode,
+        answerIndex,
+        teamKey,
+      });
+      setShowOverrideControls(false);
     }
   };
 
@@ -507,6 +533,8 @@ const HostGamePage: React.FC = () => {
             variant="host"
             isHost={true}
             controlMessage={controlMessage}
+            showOverrideControls={showOverrideControls}
+            onOverrideAnswer={handleOverrideAnswer}
           />
 
           {/* Host Controls - CLEAN VERSION */}

--- a/server/config/constants.js
+++ b/server/config/constants.js
@@ -40,6 +40,8 @@ const SOCKET_EVENTS = {
   NEXT_QUESTION: "next-question",
   FORCE_NEXT_QUESTION: "force-next-question",
   QUESTION_FORCED: "question-forced",
+  OVERRIDE_ANSWER: "override-answer",
+  ANSWER_OVERRIDDEN: "answer-overridden",
   CONTINUE_TO_NEXT_ROUND: "continue-to-next-round",
   ROUND_STARTED: "round-started",
   ROUND_COMPLETE: "round-complete",

--- a/server/services/gameService.js
+++ b/server/services/gameService.js
@@ -373,6 +373,34 @@ export function updateQuestionData(
   }
 }
 
+// Manually override answer correctness and award points
+export function overrideAnswer(gameCode, answerIndex, teamKey) {
+  const game = games[gameCode];
+  if (!game) return null;
+
+  const currentQuestion = getCurrentQuestion(game);
+  if (!currentQuestion) return null;
+
+  const answer = currentQuestion.answers[answerIndex];
+  if (!answer) return null;
+
+  // Reveal the chosen answer
+  answer.revealed = true;
+
+  const points = answer.score * game.currentRound;
+
+  const team = getTeamByAssignment(game, teamKey);
+  if (team) {
+    team.score += points;
+    team.currentRoundScore += points;
+  }
+
+  const questionNumber = game.gameState.questionsAnswered[teamKey] + 1;
+  updateQuestionData(game, teamKey, game.currentRound, questionNumber, true, points);
+
+  return game;
+}
+
 // Submit an answer - UPDATED: Single attempt system
 export function submitAnswer(gameCode, playerId, answerText) {
   const game = games[gameCode];

--- a/server/socket/hostEvents.js
+++ b/server/socket/hostEvents.js
@@ -8,6 +8,7 @@ import {
   initializeQuestionData,
   updateQuestionData,
   advanceGameState,
+  overrideAnswer,
 } from "../services/gameService.js";
 import { handleGameStateAdvancement } from "./playerEvents.js";
 
@@ -223,6 +224,19 @@ export function setupHostEvents(socket, io) {
         console.log(
           `⚠️ Host forced advance to question ${advancedGame.currentQuestionIndex + 1}`
         );
+      }
+    }
+  });
+
+  // Host overrides an answer manually
+  socket.on("override-answer", (data) => {
+    const { gameCode, answerIndex, teamKey } = data;
+    const game = getGame(gameCode);
+
+    if (game && game.hostId === socket.id && game.status === "active") {
+      const updatedGame = overrideAnswer(gameCode, answerIndex, teamKey);
+      if (updatedGame) {
+        io.to(gameCode).emit("answer-overridden", { game: updatedGame });
       }
     }
   });

--- a/server/utils/constants.js
+++ b/server/utils/constants.js
@@ -40,6 +40,8 @@ export const SOCKET_EVENTS = {
   NEXT_QUESTION: "next-question",
   FORCE_NEXT_QUESTION: "force-next-question",
   QUESTION_FORCED: "question-forced",
+  OVERRIDE_ANSWER: "override-answer",
+  ANSWER_OVERRIDDEN: "answer-overridden",
   CONTINUE_TO_NEXT_ROUND: "continue-to-next-round",
   ROUND_STARTED: "round-started",
   ROUND_COMPLETE: "round-complete",


### PR DESCRIPTION
## Summary
- add `OVERRIDE_ANSWER` and `ANSWER_OVERRIDDEN` socket events
- support manual answer override in server game service and host socket events
- expose `overrideAnswer` in socket hook
- show override controls on host UI and handle new socket event

## Testing
- `npx tsc -p frontend/tsconfig.json`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68894838c5348331bf016c15ac67342d