### PR TITLE
Add audience viewing mode

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,7 @@ import HostGamePage from "./pages/HostGamePage";
 import PlayerHomePage from "./pages/PlayerHomePage";
 import LoginPage from "./pages/Login";
 import HostHomePage from "./pages/HostHomePage";
+import AudiencePage from "./pages/AudiencePage";
 // Import constants
 import { ROUTES } from "./utils/constants";
 
@@ -20,6 +21,7 @@ const App: React.FC = () => {
         <Route path={ROUTES.PLAYERHOME} element={<PlayerHomePage />} />
         <Route path={ROUTES.HOST} element={<HostGamePage />} />
         <Route path={ROUTES.JOIN} element={<JoinGamePage />} />
+        <Route path={ROUTES.AUDIENCE} element={<AudiencePage />} />
       </Routes>
     </Router>
   );

--- a/frontend/src/hooks/useSocket.ts
+++ b/frontend/src/hooks/useSocket.ts
@@ -284,6 +284,12 @@ export const useSocket = (callbacks: SocketCallbacks = {}) => {
     }
   };
 
+  const audienceJoinGame = (gameCode: string, spectatorId: string) => {
+    if (socketRef.current) {
+      socketRef.current.emit("audience-join", { gameCode, spectatorId });
+    }
+  };
+
   const submitAnswer = (gameCode: string, playerId: string, answer: string) => {
     if (socketRef.current) {
       console.log("📝 Submitting single attempt answer:", { gameCode, playerId, answer });
@@ -330,6 +336,7 @@ export const useSocket = (callbacks: SocketCallbacks = {}) => {
     requestPlayersList,
     // Player actions
     playerJoinGame,
+    audienceJoinGame,
     submitAnswer,
     joinTeam,
   };

--- a/frontend/src/pages/AudiencePage.tsx
+++ b/frontend/src/pages/AudiencePage.tsx
@@ -1,0 +1,181 @@
+import React, { useState } from "react";
+import { Link } from "react-router-dom";
+import PageLayout from "../components/layout/PageLayout";
+import AnimatedCard from "../components/common/AnimatedCard";
+import Input from "../components/common/Input";
+import Button from "../components/common/Button";
+import GameBoard from "../components/game/GameBoard";
+import TeamPanel from "../components/game/TeamPanel";
+import TurnIndicator from "../components/game/TurnIndicator";
+import { useSocket } from "../hooks/useSocket";
+import gameApi from "../services/gameApi";
+import { Game, RoundData } from "../types";
+import { ROUTES } from "../utils/constants";
+
+const defaultRoundData: RoundData = {
+  round1: [
+    { firstAttemptCorrect: null, pointsEarned: 0 },
+    { firstAttemptCorrect: null, pointsEarned: 0 },
+    { firstAttemptCorrect: null, pointsEarned: 0 },
+  ],
+  round2: [
+    { firstAttemptCorrect: null, pointsEarned: 0 },
+    { firstAttemptCorrect: null, pointsEarned: 0 },
+    { firstAttemptCorrect: null, pointsEarned: 0 },
+  ],
+  round3: [
+    { firstAttemptCorrect: null, pointsEarned: 0 },
+    { firstAttemptCorrect: null, pointsEarned: 0 },
+    { firstAttemptCorrect: null, pointsEarned: 0 },
+  ],
+};
+
+const AudiencePage: React.FC = () => {
+  const [gameCode, setGameCode] = useState("");
+  const [spectatorName, setSpectatorName] = useState("");
+  const [spectatorId, setSpectatorId] = useState<string | null>(null);
+  const [game, setGame] = useState<Game | null>(null);
+  const [error, setError] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+
+  const { connect, audienceJoinGame } = useSocket({
+    onGameStarted: (data: any) => setGame(data.game),
+    onNextQuestion: (data: any) => setGame(data.game),
+    onAnswerRevealed: (data: any) => setGame(data.game),
+    onTurnChanged: (data: any) => setGame(data.game),
+    onRoundComplete: (data: any) => {
+      if (data.game) setGame(data.game);
+    },
+    onRoundStarted: (data: any) => setGame(data.game),
+    onGameOver: (data: any) => setGame(data.game),
+    onTeamUpdated: (data: any) => setGame(data.game),
+    onPlayersListReceived: (data: any) => {
+      setGame((prev) => (prev ? { ...prev, players: data.players } : prev));
+    },
+  });
+
+  const handleJoin = async () => {
+    if (!gameCode.trim() || !spectatorName.trim()) {
+      setError("Please enter game code and your name");
+      return;
+    }
+    setIsLoading(true);
+    setError("");
+    try {
+      const res = await gameApi.joinAudience({
+        gameCode: gameCode.toUpperCase(),
+        spectatorName: spectatorName.trim(),
+      });
+      setSpectatorId(res.spectatorId);
+      setGame(res.game);
+      connect();
+      audienceJoinGame(gameCode.toUpperCase(), res.spectatorId);
+    } catch (err: any) {
+      setError(err.response?.data?.error || "Failed to join audience");
+    }
+    setIsLoading(false);
+  };
+
+  const getTeamQuestionData = (teamKey: "team1" | "team2"): RoundData => {
+    if (!game?.gameState?.questionData?.[teamKey]) {
+      return defaultRoundData;
+    }
+    return game.gameState.questionData[teamKey];
+  };
+
+  if (!spectatorId || !game) {
+    return (
+      <PageLayout>
+        <AnimatedCard>
+          <div className="max-w-md mx-auto glass-card p-8 text-center">
+            <h2 className="text-xl font-semibold mb-4">Join as Audience</h2>
+            {error && (
+              <div className="mb-4 p-2 bg-red-500/20 border border-red-500/50 rounded text-red-300">
+                {error}
+              </div>
+            )}
+            <div className="space-y-4 mb-6">
+              <Input
+                id="gameCode"
+                value={gameCode}
+                onChange={(e) => setGameCode(e.target.value.toUpperCase())}
+                placeholder="Enter game code"
+                label="Game Code"
+                maxLength={6}
+              />
+              <Input
+                id="spectatorName"
+                value={spectatorName}
+                onChange={(e) => setSpectatorName(e.target.value)}
+                placeholder="Your name"
+                label="Name"
+              />
+            </div>
+            <Button
+              onClick={handleJoin}
+              disabled={isLoading || !gameCode || !spectatorName}
+              loading={isLoading}
+              variant="primary"
+              className="mb-4"
+            >
+              {isLoading ? "Joining..." : "Join Audience"}
+            </Button>
+            <div>
+              <Link to={ROUTES.PLAYERHOME} className="text-slate-400 hover:text-white">
+                ← Back
+              </Link>
+            </div>
+          </div>
+        </AnimatedCard>
+      </PageLayout>
+    );
+  }
+
+  const team1QuestionsAnswered = game.gameState.questionsAnswered.team1;
+  const team2QuestionsAnswered = game.gameState.questionsAnswered.team2;
+
+  return (
+    <PageLayout gameCode={game.code} variant="game">
+      <div className="w-48 flex-shrink-0">
+        <TeamPanel
+          team={game.teams[0]}
+          teamIndex={0}
+          isActive={game.teams[0]?.active}
+          showMembers={false}
+          currentRound={game.currentRound}
+          roundScore={game.teams[0].currentRoundScore}
+          questionsAnswered={team1QuestionsAnswered}
+          questionData={getTeamQuestionData("team1")}
+        />
+      </div>
+      <div className="flex-1 flex flex-col overflow-hidden">
+        <TurnIndicator
+          currentTeam={game.gameState.currentTurn}
+          teams={game.teams}
+          currentQuestion={game.questions[game.currentQuestionIndex]}
+          questionsAnswered={game.gameState.questionsAnswered}
+          round={game.currentRound}
+          variant="compact"
+        />
+        <GameBoard game={game} variant="player" />
+        <div className="text-center text-sm text-slate-400 mt-2">
+          Audience members: {game.audiences?.length ?? 1}
+        </div>
+      </div>
+      <div className="w-48 flex-shrink-0">
+        <TeamPanel
+          team={game.teams[1]}
+          teamIndex={1}
+          isActive={game.teams[1]?.active}
+          showMembers={false}
+          currentRound={game.currentRound}
+          roundScore={game.teams[1].currentRoundScore}
+          questionsAnswered={team2QuestionsAnswered}
+          questionData={getTeamQuestionData("team2")}
+        />
+      </div>
+    </PageLayout>
+  );
+};
+
+export default AudiencePage;

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -57,6 +57,20 @@ const HomePage: React.FC = () => {
               </span>
             </Button>
           </AnimatedCard>
+
+          <AnimatedCard className="flex-1" delay={600}>
+            <Button
+              onClick={() => navigate(ROUTES.AUDIENCE)}
+              variant="secondary"
+              size="xl"
+              className="w-full py-6 text-xl group"
+              icon={
+                <span className="text-3xl mr-3 group-hover:animate-bounce">🎥</span>
+              }
+            >
+              <span className="block text-sm text-blue-200 mt-1">Watch Game</span>
+            </Button>
+          </AnimatedCard>
         </div>
       </div>
     </PageLayout>

--- a/frontend/src/services/gameApi.ts
+++ b/frontend/src/services/gameApi.ts
@@ -19,6 +19,16 @@ export interface JoinGameResponse {
   game: any; // Game type from types
 }
 
+export interface JoinAudienceResponse {
+  spectatorId: string;
+  game: any;
+}
+
+export interface JoinAudienceRequest {
+  gameCode: string;
+  spectatorName: string;
+}
+
 export interface JoinGameRequest {
   gameCode: string;
   playerName: string;
@@ -40,6 +50,11 @@ export const gameApi = {
   // Join an existing game
   async joinGame(request: JoinGameRequest): Promise<JoinGameResponse> {
     const response = await apiClient.post("/api/join-game", request);
+    return response.data;
+  },
+
+  async joinAudience(request: JoinAudienceRequest): Promise<JoinAudienceResponse> {
+    const response = await apiClient.post("/api/join-audience", request);
     return response.data;
   },
 };

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -22,6 +22,7 @@ export interface Game {
   questions: Question[];
   teams: Team[];
   players: Player[];
+  audiences?: { id: string; name: string }[];
   hostId: string | null;
   createdAt: Date;
   // Turn-based game state with 3-attempt rule

--- a/frontend/src/utils/constants.ts
+++ b/frontend/src/utils/constants.ts
@@ -15,6 +15,7 @@ export const ROUTES = {
   PLAYERHOME: "/PlayerHomePage",
   HOST: "/host",
   JOIN: "/join",
+  AUDIENCE: "/audience",
 } as const;
 
 export const GAME_STATUS = {

--- a/server/routes/gameRoutes.js
+++ b/server/routes/gameRoutes.js
@@ -1,5 +1,5 @@
 import { Router } from "express";
-import { joinGame, getGameStats, createGame } from "../services/gameService.js";
+import { joinGame, joinAudience, getGameStats, createGame } from "../services/gameService.js";
 import { ApiError } from "../utils/ApiError.js";
 import { prepareGameQuestions } from "../services/loadQuestionFromDB.js";
 
@@ -108,6 +108,28 @@ router.post("/api/join-game", (req, res) => {
         error: "Failed to join game",
         details: error.message,
       });
+    }
+  }
+});
+
+// Join as audience
+router.post("/api/join-audience", (req, res) => {
+  try {
+    const { gameCode, spectatorName } = req.body;
+    if (!gameCode || !spectatorName) {
+      return res.status(400).json({ error: "Game code and name are required" });
+    }
+    const { spectatorId, game } = joinAudience(
+      gameCode.toUpperCase(),
+      spectatorName.trim()
+    );
+    res.json({ spectatorId, game, success: true });
+  } catch (error) {
+    console.error("Error joining audience:", error);
+    if (error.message === "Game not found") {
+      res.status(404).json({ error: "Game not found" });
+    } else {
+      res.status(500).json({ error: "Failed to join audience" });
     }
   }
 });

--- a/server/services/gameService.js
+++ b/server/services/gameService.js
@@ -4,6 +4,7 @@ import { GameQuestion } from "../models/gameQuestion.model.js";
 // In-memory storage
 export let games = {};
 export let players = {};
+export let audiences = {};
 
 // Generate random game code
 export function generateGameCode() {
@@ -281,6 +282,7 @@ export async function createGame(updatedQuestions, tossUpQuestion) {
       },
     ],
     players: [],
+    audiences: [],
     hostId: null,
     createdAt: new Date(),
     buzzedTeamId: null,
@@ -708,6 +710,27 @@ export function joinGame(gameCode, playerName) {
   return { playerId, game: games[gameCode] };
 }
 
+// Join as an audience member
+export function joinAudience(gameCode, spectatorName) {
+  if (!games[gameCode]) {
+    throw new Error("Game not found");
+  }
+
+  const spectatorId = uuidv4();
+  const spectator = {
+    id: spectatorId,
+    name: spectatorName,
+    gameCode,
+    connected: true,
+  };
+
+  audiences[spectatorId] = spectator;
+  games[gameCode].audiences.push(spectator);
+
+  console.log(`👀 Audience joined: ${spectatorName} in game ${gameCode}`);
+  return { spectatorId, game: games[gameCode] };
+}
+
 // Get game by code
 export function getGame(gameCode) {
   return games[gameCode] || null;
@@ -716,6 +739,10 @@ export function getGame(gameCode) {
 // Get player by ID
 export function getPlayer(playerId) {
   return players[playerId] || null;
+}
+
+export function getAudience(spectatorId) {
+  return audiences[spectatorId] || null;
 }
 
 // Update game

--- a/server/socket/playerEvents.js
+++ b/server/socket/playerEvents.js
@@ -1,6 +1,7 @@
 import {
   getGame,
   getPlayer,
+  getAudience,
   updatePlayer,
   submitAnswer,
   updateGame,
@@ -46,6 +47,18 @@ export function setupPlayerEvents(socket, io) {
       console.error(
         `❌ Player join failed: game=${!!game}, player=${!!player}`
       );
+    }
+  });
+
+  // Audience joins game room
+  socket.on("audience-join", (data) => {
+    const { gameCode, spectatorId } = data;
+    const game = getGame(gameCode);
+    const spectator = getAudience(spectatorId);
+    if (game && spectator) {
+      socket.join(gameCode);
+      spectator.socketId = socket.id;
+      console.log(`👀 Audience ${spectator.name} joined room ${gameCode}`);
     }
   });
 


### PR DESCRIPTION
## Summary
- add audience route constant
- implement `AudiencePage` with join form and read-only game board
- add watch option on HomePage
- include audience route in router
- extend server to handle audience members and join endpoint
- expose audience join socket event
- add API & socket helpers for audience join

## Testing
- `npm test --prefix frontend -- --watchAll=false --passWithNoTests`
- `npm test --prefix server` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688d0e8f37648331a2b9bda3372c8a71