### PR TITLE
feat: improve mobile input support

### DIFF
--- a/frontend/src/components/common/Input.tsx
+++ b/frontend/src/components/common/Input.tsx
@@ -5,7 +5,7 @@ interface InputProps {
   type?: "text" | "email" | "password" | "number";
   value: string;
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
-  onKeyPress?: (e: React.KeyboardEvent<HTMLInputElement>) => void;
+  onKeyDown?: (e: React.KeyboardEvent<HTMLInputElement>) => void;
   placeholder?: string;
   label?: string;
   disabled?: boolean;
@@ -21,7 +21,7 @@ const Input: React.FC<InputProps> = ({
   type = "text",
   value,
   onChange,
-  onKeyPress,
+  onKeyDown,
   placeholder,
   label,
   disabled = false,
@@ -55,7 +55,7 @@ const Input: React.FC<InputProps> = ({
         type={type}
         value={value}
         onChange={onChange}
-        onKeyPress={onKeyPress}
+        onKeyDown={onKeyDown}
         placeholder={placeholder}
         disabled={disabled}
         required={required}

--- a/frontend/src/components/forms/AudienceJoinForm.tsx
+++ b/frontend/src/components/forms/AudienceJoinForm.tsx
@@ -20,7 +20,7 @@ const AudienceJoinForm: React.FC<AudienceJoinFormProps> = ({
   isLoading,
   error,
 }) => {
-  const handleKeyPress = (e: React.KeyboardEvent<HTMLInputElement>) => {
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === "Enter") {
       onJoin();
     }
@@ -46,7 +46,7 @@ const AudienceJoinForm: React.FC<AudienceJoinFormProps> = ({
               id="gameCode"
               value={gameCode}
               onChange={(e) => onGameCodeChange(e.target.value.toUpperCase())}
-              onKeyPress={handleKeyPress}
+              onKeyDown={handleKeyDown}
               placeholder="Enter 6-digit code"
               label="Game Code"
               variant="center"

--- a/frontend/src/components/forms/HostJoinForm.tsx
+++ b/frontend/src/components/forms/HostJoinForm.tsx
@@ -20,7 +20,7 @@ const HostJoinForm: React.FC<HostJoinFormProps> = ({
   isLoading,
   error,
 }) => {
-  const handleKeyPress = (e: React.KeyboardEvent<HTMLInputElement>) => {
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === "Enter") {
       onJoin();
     }
@@ -46,7 +46,7 @@ const HostJoinForm: React.FC<HostJoinFormProps> = ({
               id="hostGameCode"
               value={gameCode}
               onChange={(e) => onGameCodeChange(e.target.value.toUpperCase())}
-              onKeyPress={handleKeyPress}
+              onKeyDown={handleKeyDown}
               placeholder="Enter 6-digit code"
               label="Game Code"
               variant="center"

--- a/frontend/src/components/forms/JoinGameForm.tsx
+++ b/frontend/src/components/forms/JoinGameForm.tsx
@@ -24,7 +24,7 @@ const JoinGameForm: React.FC<JoinGameFormProps> = ({
   error,
 }) => {
   const playerName = localStorage.getItem("username") || "Player";
-  const handleKeyPress = (e: React.KeyboardEvent<HTMLInputElement>) => {
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     localStorage.setItem("playerName", playerName);
     if (e.key === "Enter") {
       onJoinGame();
@@ -58,7 +58,7 @@ const JoinGameForm: React.FC<JoinGameFormProps> = ({
               id="gameCode"
               value={gameCode}
               onChange={(e) => onGameCodeChange(e.target.value.toUpperCase())}
-              onKeyPress={handleKeyPress}
+              onKeyDown={handleKeyDown}
               placeholder="Enter 6-digit code"
               label="Game Code"
               variant="center"
@@ -70,7 +70,7 @@ const JoinGameForm: React.FC<JoinGameFormProps> = ({
               id="playerName"
               value={playerName}
               onChange={(e) => onPlayerNameChange(e.target.value)}
-              onKeyPress={handleKeyPress}
+              onKeyDown={handleKeyDown}
               placeholder="Enter your name"
               label="Your Name"
               disabled={isLoading}

--- a/frontend/src/components/game/AnswerInput.tsx
+++ b/frontend/src/components/game/AnswerInput.tsx
@@ -59,7 +59,7 @@ const AnswerInput: React.FC<AnswerInputProps> = ({
               : "border-slate-400 bg-slate-50/5 opacity-60"
           }`}
           disabled={!canSubmit}
-          autoFocus={!!canSubmit}
+          autoFocus={canSubmit}
         />
 
         {isMyTeam && (

--- a/frontend/src/components/game/AnswerInput.tsx
+++ b/frontend/src/components/game/AnswerInput.tsx
@@ -23,7 +23,7 @@ const AnswerInput: React.FC<AnswerInputProps> = ({
   currentAttempt = 1,
   maxAttempts = 3,
 }) => {
-  const handleKeyPress = (e: React.KeyboardEvent<HTMLInputElement>) => {
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === "Enter" && canSubmit && answer.trim()) {
       onSubmit();
     }
@@ -49,7 +49,7 @@ const AnswerInput: React.FC<AnswerInputProps> = ({
         <Input
           value={answer}
           onChange={(e) => onAnswerChange(e.target.value)}
-          onKeyPress={handleKeyPress}
+          onKeyDown={handleKeyDown}
           placeholder={
             isMyTeam ? "Enter your answer..." : "Wait for your turn..."
           }

--- a/frontend/src/components/game/BuzzerButton.tsx
+++ b/frontend/src/components/game/BuzzerButton.tsx
@@ -20,6 +20,7 @@ const BuzzerButton: React.FC<BuzzerButtonProps> = ({
       </h3>
       <button
         onClick={onBuzz}
+        onTouchStart={onBuzz}
         disabled={disabled || loading}
         className={`w-full text-xl font-bold py-6 px-8 rounded-xl transition-all transform ${
           !disabled && !loading

--- a/frontend/src/components/game/GameBoard.tsx
+++ b/frontend/src/components/game/GameBoard.tsx
@@ -75,9 +75,9 @@ const GameBoard: React.FC<GameBoardProps> = ({
 
   if (variant === "player") {
     return (
-      <div className="flex-1 flex flex-col overflow-hidden">
+      <div className="flex-1 flex flex-col overflow-y-auto">
         {/* Question Header - Compact with Round Status */}
-        <div className="glass-card question-header bg-gradient-to-r from-purple-600/20 to-blue-600/20 border-purple-500/30">
+        <div className="glass-card question-header flex-shrink-0 bg-gradient-to-r from-purple-600/20 to-blue-600/20 border-purple-500/30">
           <div className="flex justify-between items-center">
             <div>
               <h2 className="font-bold">
@@ -96,7 +96,7 @@ const GameBoard: React.FC<GameBoardProps> = ({
         </div>
 
         {/* Question Text - Compact */}
-        <div className="glass-card question-card">
+        <div className="glass-card question-card flex-shrink-0">
           <h2 className="text-center">{currentQuestion.question}</h2>
         </div>
 
@@ -143,9 +143,9 @@ const GameBoard: React.FC<GameBoardProps> = ({
   }
 
   return (
-    <div className="flex-1 flex flex-col overflow-hidden">
+      <div className="flex-1 flex flex-col overflow-y-auto">
       {/* Question Header with Round Status */}
-      <div className="glass-card question-header bg-gradient-to-r from-purple-600/20 to-blue-600/20 border-purple-500/30">
+      <div className="glass-card question-header flex-shrink-0 bg-gradient-to-r from-purple-600/20 to-blue-600/20 border-purple-500/30">
         <div className="flex justify-between items-center">
           <div>
             <h2 className="font-bold">
@@ -164,7 +164,7 @@ const GameBoard: React.FC<GameBoardProps> = ({
       </div>
 
       {/* Question Text */}
-      <div className="glass-card question-card">
+      <div className="glass-card question-card flex-shrink-0">
         <h2 className="text-center">{currentQuestion.question}</h2>
       </div>
 

--- a/frontend/src/components/game/GameBoard.tsx
+++ b/frontend/src/components/game/GameBoard.tsx
@@ -76,28 +76,31 @@ const GameBoard: React.FC<GameBoardProps> = ({
   if (variant === "player") {
     return (
       <div className="flex-1 flex flex-col overflow-y-auto">
-        {/* Question Header - Compact with Round Status */}
-        <div className="glass-card question-header flex-shrink-0 bg-gradient-to-r from-purple-600/20 to-blue-600/20 border-purple-500/30">
-          <div className="flex justify-between items-center">
-            <div>
-              <h2 className="font-bold">
-                {game.currentRound === 0
-                  ? 'Toss-up Round'
-                  : `Round ${game.currentRound}`} •{' '}
-                {currentQuestion.questionCategory}
-              </h2>
-              <div className="text-xs text-slate-400">
-                Question {game.currentRound === 0 ? 1 : game.currentQuestionIndex + 1} of{' '}
-                {game.currentRound === 0 ? 1 : game.questions.length}
+        {/* Keep question visible on mobile by sticking it to the top */}
+        <div className="sticky top-0 z-10">
+          {/* Question Header - Compact with Round Status */}
+          <div className="glass-card question-header flex-shrink-0 bg-gradient-to-r from-purple-600/20 to-blue-600/20 border-purple-500/30">
+            <div className="flex justify-between items-center">
+              <div>
+                <h2 className="font-bold">
+                  {game.currentRound === 0
+                    ? 'Toss-up Round'
+                    : `Round ${game.currentRound}`} •{' '}
+                  {currentQuestion.questionCategory}
+                </h2>
+                <div className="text-xs text-slate-400">
+                  Question {game.currentRound === 0 ? 1 : game.currentQuestionIndex + 1} of{' '}
+                  {game.currentRound === 0 ? 1 : game.questions.length}
+                </div>
               </div>
+              <RoundStatus />
             </div>
-            <RoundStatus />
           </div>
-        </div>
 
-        {/* Question Text - Compact */}
-        <div className="glass-card question-card flex-shrink-0">
-          <h2 className="text-center">{currentQuestion.question}</h2>
+          {/* Question Text - Compact */}
+          <div className="glass-card question-card flex-shrink-0">
+            <h2 className="text-center">{currentQuestion.question}</h2>
+          </div>
         </div>
 
         {/* Answer Grid - Vertical Layout */}
@@ -144,28 +147,31 @@ const GameBoard: React.FC<GameBoardProps> = ({
 
   return (
       <div className="flex-1 flex flex-col overflow-y-auto">
-      {/* Question Header with Round Status */}
-      <div className="glass-card question-header flex-shrink-0 bg-gradient-to-r from-purple-600/20 to-blue-600/20 border-purple-500/30">
-        <div className="flex justify-between items-center">
-          <div>
-            <h2 className="font-bold">
-              {game.currentRound === 0
-                ? 'Toss-up Round'
-                : `Round ${game.currentRound}`} •{' '}
-              {currentQuestion.questionCategory}
-            </h2>
-            <div className="text-xs text-slate-400">
-              Question {game.currentRound === 0 ? 1 : game.currentQuestionIndex + 1} of{' '}
-              {game.currentRound === 0 ? 1 : game.questions.length}
+      {/* Keep question visible on mobile by sticking it to the top */}
+      <div className="sticky top-0 z-10">
+        {/* Question Header with Round Status */}
+        <div className="glass-card question-header flex-shrink-0 bg-gradient-to-r from-purple-600/20 to-blue-600/20 border-purple-500/30">
+          <div className="flex justify-between items-center">
+            <div>
+              <h2 className="font-bold">
+                {game.currentRound === 0
+                  ? 'Toss-up Round'
+                  : `Round ${game.currentRound}`} •{' '}
+                {currentQuestion.questionCategory}
+              </h2>
+              <div className="text-xs text-slate-400">
+                Question {game.currentRound === 0 ? 1 : game.currentQuestionIndex + 1} of{' '}
+                {game.currentRound === 0 ? 1 : game.questions.length}
+              </div>
             </div>
+            <RoundStatus />
           </div>
-          <RoundStatus />
         </div>
-      </div>
 
-      {/* Question Text */}
-      <div className="glass-card question-card flex-shrink-0">
-        <h2 className="text-center">{currentQuestion.question}</h2>
+        {/* Question Text */}
+        <div className="glass-card question-card flex-shrink-0">
+          <h2 className="text-center">{currentQuestion.question}</h2>
+        </div>
       </div>
 
       {/* Answer Grid - Vertical Layout for Host - Only 3 answers, Host sees all */}

--- a/frontend/src/components/game/TeamPanel.tsx
+++ b/frontend/src/components/game/TeamPanel.tsx
@@ -172,7 +172,7 @@ const TeamPanel: React.FC<TeamPanelProps> = ({
 
   return (
     <div
-      className={`glass-card p-3 h-full flex flex-col transition-all ${
+      className={`glass-card p-3 md:h-full flex flex-col transition-all ${
         isActive ? `border-2 border-red-500` : "border border-gray-300"
       } ${
         isPlayerTeam ? "border-yellow-400/50 bg-yellow-400/10" : ""

--- a/frontend/src/components/layout/PageLayout.tsx
+++ b/frontend/src/components/layout/PageLayout.tsx
@@ -21,13 +21,13 @@ const PageLayout: React.FC<PageLayoutProps> = ({
 }) => {
   const layoutClasses = {
     default: "min-h-screen flex flex-col gradient-bg",
-    game: "h-screen flex flex-col gradient-bg game-bg overflow-hidden",
+    game: "min-h-screen flex flex-col gradient-bg game-bg",
     fullscreen: "h-screen flex flex-col gradient-bg overflow-hidden", // Updated this line
   };
 
   const mainClasses = {
     default: "flex-1 container mx-auto px-4 py-8",
-    game: "flex-1 flex gap-2 p-2 overflow-hidden",
+    game: "flex-1 flex flex-col md:flex-row gap-2 p-2 overflow-auto",
     fullscreen: "flex-1 relative overflow-hidden", // Updated this line
   };
 

--- a/frontend/src/pages/AudienceGamePage.tsx
+++ b/frontend/src/pages/AudienceGamePage.tsx
@@ -226,7 +226,7 @@ const AudienceGamePage: React.FC = () => {
     const team2Answered = game.gameState.questionsAnswered.team2 || 0;
     return (
       <PageLayout gameCode={game.code} variant="game">
-        <div className="w-48 flex-shrink-0">
+        <div className="w-full md:w-48 md:flex-shrink-0">
           <TeamPanel
             team={game.teams[0]}
             teamIndex={0}
@@ -238,7 +238,7 @@ const AudienceGamePage: React.FC = () => {
             questionData={getTeamQuestionData("team1")}
           />
         </div>
-        <div className="flex-1 flex flex-col overflow-hidden">
+        <div className="flex-1 flex flex-col overflow-y-auto">
           <TurnIndicator
             currentTeam={game.gameState.currentTurn}
             teams={game.teams}
@@ -258,7 +258,7 @@ const AudienceGamePage: React.FC = () => {
             </div>
           )}
         </div>
-        <div className="w-48 flex-shrink-0">
+        <div className="w-full md:w-48 md:flex-shrink-0">
           <TeamPanel
             team={game.teams[1]}
             teamIndex={1}

--- a/frontend/src/pages/AudienceGamePage.tsx
+++ b/frontend/src/pages/AudienceGamePage.tsx
@@ -226,7 +226,7 @@ const AudienceGamePage: React.FC = () => {
     const team2Answered = game.gameState.questionsAnswered.team2 || 0;
     return (
       <PageLayout gameCode={game.code} variant="game">
-        <div className="w-full md:w-48 md:flex-shrink-0">
+        <div className="order-2 md:order-none w-full md:w-48 md:flex-shrink-0">
           <TeamPanel
             team={game.teams[0]}
             teamIndex={0}
@@ -238,7 +238,7 @@ const AudienceGamePage: React.FC = () => {
             questionData={getTeamQuestionData("team1")}
           />
         </div>
-        <div className="flex-1 flex flex-col overflow-y-auto">
+        <div className="order-1 md:order-none flex-1 flex flex-col overflow-y-auto">
           <TurnIndicator
             currentTeam={game.gameState.currentTurn}
             teams={game.teams}
@@ -258,7 +258,7 @@ const AudienceGamePage: React.FC = () => {
             </div>
           )}
         </div>
-        <div className="w-full md:w-48 md:flex-shrink-0">
+        <div className="order-3 md:order-none w-full md:w-48 md:flex-shrink-0">
           <TeamPanel
             team={game.teams[1]}
             teamIndex={1}

--- a/frontend/src/pages/HostGamePage.tsx
+++ b/frontend/src/pages/HostGamePage.tsx
@@ -617,7 +617,7 @@ const HostGamePage: React.FC = () => {
     return (
       <PageLayout gameCode={gameCode} timer={timer} variant="game">
         {/* Left Team Panel with Question Data */}
-        <div className="w-48 flex-shrink-0">
+        <div className="w-full md:w-48 md:flex-shrink-0">
           <TeamPanel
             team={game.teams[0]}
             teamIndex={0}
@@ -631,7 +631,7 @@ const HostGamePage: React.FC = () => {
         </div>
 
         {/* Center Game Area */}
-        <div className="flex-1 flex flex-col overflow-hidden">
+        <div className="flex-1 flex flex-col overflow-y-auto">
           {/* Turn Indicator */}
           <TurnIndicator
             currentTeam={game.gameState.currentTurn}
@@ -704,7 +704,7 @@ const HostGamePage: React.FC = () => {
         </div>
 
         {/* Right Team Panel with Question Data */}
-        <div className="w-48 flex-shrink-0">
+        <div className="w-full md:w-48 md:flex-shrink-0">
           <TeamPanel
             team={game.teams[1]}
             teamIndex={1}

--- a/frontend/src/pages/HostGamePage.tsx
+++ b/frontend/src/pages/HostGamePage.tsx
@@ -617,7 +617,7 @@ const HostGamePage: React.FC = () => {
     return (
       <PageLayout gameCode={gameCode} timer={timer} variant="game">
         {/* Left Team Panel with Question Data */}
-        <div className="w-full md:w-48 md:flex-shrink-0">
+        <div className="order-2 md:order-none w-full md:w-48 md:flex-shrink-0">
           <TeamPanel
             team={game.teams[0]}
             teamIndex={0}
@@ -631,7 +631,7 @@ const HostGamePage: React.FC = () => {
         </div>
 
         {/* Center Game Area */}
-        <div className="flex-1 flex flex-col overflow-y-auto">
+        <div className="order-1 md:order-none flex-1 flex flex-col overflow-y-auto">
           {/* Turn Indicator */}
           <TurnIndicator
             currentTeam={game.gameState.currentTurn}
@@ -704,7 +704,7 @@ const HostGamePage: React.FC = () => {
         </div>
 
         {/* Right Team Panel with Question Data */}
-        <div className="w-full md:w-48 md:flex-shrink-0">
+        <div className="order-3 md:order-none w-full md:w-48 md:flex-shrink-0">
           <TeamPanel
             team={game.teams[1]}
             teamIndex={1}

--- a/frontend/src/pages/JoinGamePage.tsx
+++ b/frontend/src/pages/JoinGamePage.tsx
@@ -355,7 +355,7 @@ const JoinGamePage: React.FC = () => {
     }
   };
 
-  const handleKeyPress = (e: React.KeyboardEvent<HTMLInputElement>) => {
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === "Enter" && answer.trim()) {
       handleSubmitAnswer();
     }
@@ -443,7 +443,7 @@ const JoinGamePage: React.FC = () => {
     return (
       <PageLayout gameCode={game.code} variant="game">
         {/* Left Team Panel with Question Data */}
-        <div className="w-48 flex-shrink-0">
+        <div className="w-full md:w-48 md:flex-shrink-0">
           <TeamPanel
             team={game.teams[0]}
             teamIndex={0}
@@ -461,7 +461,7 @@ const JoinGamePage: React.FC = () => {
         </div>
 
         {/* Center Game Area */}
-        <div className="flex-1 flex flex-col overflow-hidden">
+        <div className="flex-1 flex flex-col overflow-y-auto">
           {/* Turn Indicator */}
           <TurnIndicator
             currentTeam={game.gameState.currentTurn}
@@ -511,7 +511,7 @@ const JoinGamePage: React.FC = () => {
                         type="text"
                         value={answer}
                         onChange={(e) => setAnswer(e.target.value)}
-                        onKeyPress={handleKeyPress}
+                        onKeyDown={handleKeyDown}
                         placeholder="Type your answer here..."
                         disabled={!canAnswer}
                         autoFocus={true}
@@ -536,7 +536,7 @@ const JoinGamePage: React.FC = () => {
                       type="text"
                       value={answer}
                       onChange={(e) => setAnswer(e.target.value)}
-                      onKeyPress={handleKeyPress}
+                      onKeyDown={handleKeyDown}
                       placeholder="Type your answer here..."
                       disabled={!canAnswer}
                       autoFocus={true}
@@ -577,7 +577,7 @@ const JoinGamePage: React.FC = () => {
         </div>
 
         {/* Right Team Panel with Question Data */}
-        <div className="w-48 flex-shrink-0">
+        <div className="w-full md:w-48 md:flex-shrink-0">
           <TeamPanel
             team={game.teams[1]}
             teamIndex={1}


### PR DESCRIPTION
## Summary
- support touch events for buzzing
- switch input handlers to keydown for mobile browsers
- improve portrait layout and ensure questions stay visible on mobile

## Testing
- `npm test -- --watchAll=false` (frontend) *(fails: No tests found)*
- `npm test` (root) *(fails: Could not read package.json)*
- `npm test` (server) *(fails: Error: no test specified)*
- `npm run build` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_689c7f89ac548331a0ab7f51a399df3e